### PR TITLE
Add sub-control functionality

### DIFF
--- a/app/Filament/Resources/AuditResource/Pages/CreateAudit.php
+++ b/app/Filament/Resources/AuditResource/Pages/CreateAudit.php
@@ -132,6 +132,7 @@ class CreateAudit extends CreateRecord
 
                                 if ($audit_type == 'standards') {
                                     $controls = Control::where('standard_id', '=', $standard_id)
+                                        ->whereNull('parent_control_id')
                                         ->get()
                                         ->mapWithKeys(function ($control) {
                                             return [$control->id => $control->code.' - '.$control->title];
@@ -148,6 +149,7 @@ class CreateAudit extends CreateRecord
                                     if ($program_id) {
                                         $program = Program::find($program_id);
                                         $controls = $program->getAllControls()
+                                            ->whereNull('parent_control_id')
                                             ->mapWithKeys(function ($control) {
                                                 return [$control->id => $control->code.' - '.$control->title];
                                             });

--- a/app/Filament/Resources/AuditResource/RelationManagers/AuditItemRelationManager.php
+++ b/app/Filament/Resources/AuditResource/RelationManagers/AuditItemRelationManager.php
@@ -40,6 +40,10 @@ class AuditItemRelationManager extends RelationManager
                             ->label('Control Discussion')
                             ->content(fn (AuditItem $record): HtmlString => new HtmlString(optional($record->control)->discussion ?? ''))
                             ->columnSpanFull(),
+                        Placeholder::make('sub_controls')
+                            ->label('Sub Controls')
+                            ->content(fn (AuditItem $record): HtmlString => new HtmlString($this->subControlsList($record)))
+                            ->columnSpanFull(),
 
                     ])->columns(2)->collapsible(true),
 
@@ -166,6 +170,21 @@ class AuditItemRelationManager extends RelationManager
 
         // Return the generated HTML as an HtmlString
         return new HtmlString($html);
+    }
+
+    protected function subControlsList(AuditItem $record): string
+    {
+        $subs = $record->control?->subControls ?? [];
+        if ($subs instanceof \Illuminate\Support\Collection && $subs->isNotEmpty()) {
+            $list = '<ul class="list-disc ml-6">';
+            foreach ($subs as $sub) {
+                $list .= '<li>'.e($sub->code).' - '.e($sub->title).'</li>';
+            }
+            $list .= '</ul>';
+            return $list;
+        }
+
+        return 'None';
     }
 
     public function table(Table $table): Table

--- a/app/Filament/Resources/ControlResource.php
+++ b/app/Filament/Resources/ControlResource.php
@@ -125,8 +125,8 @@ class ControlResource extends Resource
             {
                 public function toHtml()
                 {
-                    return "<div class='fi-section-content p-6'>" . 
-                        __('control.table.description') . 
+                    return "<div class='fi-section-content p-6'>" .
+                        __('control.table.description') .
                         "</div>";
                 }
             })
@@ -218,9 +218,9 @@ class ControlResource extends Resource
     public static function getRelations(): array
     {
         return [
-            RelationManagers\ImplementationRelationManager::class,
-            RelationManagers\AuditItemRelationManager::class,
             RelationManagers\SubControlRelationManager::class,
+            RelationManagers\ImplementationRelationManager::class,
+            RelationManagers\AuditItemRelationManager::class
         ];
     }
 
@@ -269,12 +269,12 @@ class ControlResource extends Resource
                             ->html(),
                         TextEntry::make('discussion')
                             ->columnSpanFull()
-                            ->hidden(fn (Control $record) => ! $record->discussion)
+                            ->hidden(fn(Control $record) => ! $record->discussion)
                             ->html(),
                         TextEntry::make('test')
                             ->label(__('control.infolist.test_plan'))
                             ->columnSpanFull()
-                            ->hidden(fn (Control $record) => ! $record->discussion)
+                            ->hidden(fn(Control $record) => ! $record->discussion)
                             ->html(),
                     ]),
             ]);

--- a/app/Filament/Resources/ControlResource.php
+++ b/app/Filament/Resources/ControlResource.php
@@ -81,6 +81,12 @@ class ControlResource extends Resource
                     ->options(Standard::pluck('name', 'id')->toArray())
                     ->hintIcon('heroicon-m-question-mark-circle', tooltip: __('control.form.standard.tooltip'))
                     ->required(),
+                Forms\Components\Select::make('parent_control_id')
+                    ->label('Parent Control')
+                    ->options(Control::whereNull('parent_control_id')->pluck('title', 'id'))
+                    ->searchable()
+                    ->preload()
+                    ->nullable(),
                 Forms\Components\Select::make('enforcement')
                     ->options(ControlEnforcementCategory::class)
                     ->hintIcon('heroicon-m-question-mark-circle', tooltip: __('control.form.enforcement.tooltip'))
@@ -214,6 +220,7 @@ class ControlResource extends Resource
         return [
             RelationManagers\ImplementationRelationManager::class,
             RelationManagers\AuditItemRelationManager::class,
+            RelationManagers\SubControlRelationManager::class,
         ];
     }
 
@@ -232,7 +239,8 @@ class ControlResource extends Resource
         return parent::getEloquentQuery()
             ->withoutGlobalScopes([
                 SoftDeletingScope::class,
-            ]);
+            ])
+            ->whereNull('parent_control_id');
     }
 
     public static function infolist(Infolist $infolist): Infolist

--- a/app/Filament/Resources/ControlResource/RelationManagers/SubControlRelationManager.php
+++ b/app/Filament/Resources/ControlResource/RelationManagers/SubControlRelationManager.php
@@ -2,6 +2,9 @@
 
 namespace App\Filament\Resources\ControlResource\RelationManagers;
 
+use AmidEsfahani\FilamentTinyEditor\TinyEditor;
+use App\Enums\Applicability;
+use App\Models\Control;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Resources\RelationManagers\RelationManager;
@@ -16,8 +19,40 @@ class SubControlRelationManager extends RelationManager
     {
         return $form
             ->schema([
-                Forms\Components\TextInput::make('title')->required()->maxLength(1024),
-                Forms\Components\TextInput::make('code')->required()->maxLength(255),
+                Forms\Components\TextInput::make('code')
+                    ->required()
+                    ->maxLength(255)
+                    ->placeholder('e.g. 3.1.1')
+                    ->hintIcon('heroicon-m-question-mark-circle', tooltip: 'Give the control a unique ID or Code.'),
+                Forms\Components\Select::make('applicability')
+                    ->default(Applicability::UNKNOWN)
+                    ->required()
+                    ->enum(Applicability::class)
+                    ->options(Applicability::class)
+                    ->hintIcon('heroicon-m-question-mark-circle', tooltip: 'Select the relevance of this standard to your organization.')
+                    ->native(false),
+                Forms\Components\TextInput::make('title')
+                    ->required()
+                    ->columnSpanFull()
+                    ->maxLength(1024)
+                    ->placeholder('e.g. Limit system access to authorized users, processes acting on behalf of authorized users, and devices (including other systems).')
+                    ->hint('Enter the title of the control.')
+                    ->hintIcon('heroicon-m-question-mark-circle', tooltip: 'This should be a succinct description of the control.'),
+                Forms\Components\RichEditor::make('description')
+                    ->required()
+                    ->disableToolbarButtons([
+                        'image',
+                        'attachFiles'
+                    ])
+                    ->hintIcon('heroicon-m-question-mark-circle', tooltip: 'Describe the control in detail.')
+                    ->columnSpanFull(),
+                Forms\Components\RichEditor::make('discussion')
+                    ->columnSpanFull()
+                    ->disableToolbarButtons([
+                        'image',
+                        'attachFiles'
+                    ])
+                    ->hintIcon('heroicon-m-question-mark-circle', tooltip: 'Provide any explanation, discussion, context, or relevant information to help someone understand the intent of this control.'),
             ]);
     }
 
@@ -26,10 +61,17 @@ class SubControlRelationManager extends RelationManager
         return $table
             ->columns([
                 Tables\Columns\TextColumn::make('code')->searchable()->sortable(),
+                Tables\Columns\TextColumn::make('applicability')->searchable()->sortable()->wrap(),
                 Tables\Columns\TextColumn::make('title')->searchable()->sortable()->wrap(),
             ])
             ->headerActions([
-                Tables\Actions\CreateAction::make(),
+                Tables\Actions\CreateAction::make()
+                    ->using(function (array $data, RelationManager $livewire) {
+                        $owner = $livewire->getOwnerRecord();
+                        $data['standard_id'] = $owner->standard_id;
+                        $data['parent_control_id'] = $owner->id;
+                        return Control::create($data);
+                    }),
             ])
             ->actions([
                 Tables\Actions\EditAction::make(),

--- a/app/Filament/Resources/ControlResource/RelationManagers/SubControlRelationManager.php
+++ b/app/Filament/Resources/ControlResource/RelationManagers/SubControlRelationManager.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Filament\Resources\ControlResource\RelationManagers;
+
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class SubControlRelationManager extends RelationManager
+{
+    protected static string $relationship = 'subControls';
+
+    public function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\TextInput::make('title')->required()->maxLength(1024),
+                Forms\Components\TextInput::make('code')->required()->maxLength(255),
+            ]);
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('code')->searchable()->sortable(),
+                Tables\Columns\TextColumn::make('title')->searchable()->sortable()->wrap(),
+            ])
+            ->headerActions([
+                Tables\Actions\CreateAction::make(),
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\DeleteAction::make(),
+            ]);
+    }
+}

--- a/app/Models/Control.php
+++ b/app/Models/Control.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Carbon;
 
 /**
@@ -73,6 +74,7 @@ class Control extends Model
         'type' => ControlType::class,
         'category' => ControlCategory::class,
         'enforcement' => ControlEnforcementCategory::class,
+        'parent_control_id' => 'integer',
     ];
 
     /**
@@ -97,6 +99,22 @@ class Control extends Model
     public function standard(): BelongsTo
     {
         return $this->belongsTo(Standard::class);
+    }
+
+    /**
+     * Get the parent control if this control is a sub-control.
+     */
+    public function parent(): BelongsTo
+    {
+        return $this->belongsTo(self::class, 'parent_control_id');
+    }
+
+    /**
+     * Get the sub-controls for this control.
+     */
+    public function subControls(): HasMany
+    {
+        return $this->hasMany(self::class, 'parent_control_id');
     }
 
     /**

--- a/database/migrations/2025_05_05_000000_add_parent_control_id_to_controls_table.php
+++ b/database/migrations/2025_05_05_000000_add_parent_control_id_to_controls_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('controls', function (Blueprint $table) {
+            $table->foreignId('parent_control_id')
+                ->nullable()
+                ->constrained('controls')
+                ->nullOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('controls', function (Blueprint $table) {
+            $table->dropForeign(['parent_control_id']);
+            $table->dropColumn('parent_control_id');
+        });
+    }
+};

--- a/resources/views/reports/audit.blade.php
+++ b/resources/views/reports/audit.blade.php
@@ -135,8 +135,28 @@
                 </tr>
                 <tr>
                     <td>Control</td>
-                    <td colspan="3">{{ $item->auditable->code }} {{ $item->auditable->title }}
+                    <td colspan="3">{{ $item->auditable->title }}
                         <br>{!! $item->auditable->description !!}</td>
+                </tr>
+                 <tr>
+                    <td>Sub-controls</td>
+                    <td colspan="3">
+                        <ul>
+                             @foreach($item->auditable->subControls as $subControl)
+                             <li>
+                             {!!  $subControl->code  !!}
+                            {!!  $subControl->title  !!}
+                            <br>{!!  $subControl->description  !!}
+                              </li>
+                        @endforeach
+                           
+                                
+                          
+                        </ul>
+                       
+
+
+                    </td>
                 </tr>
                 <tr>
                     <td>Auditor Notes</td>

--- a/resources/views/tables/controls-table.blade.php
+++ b/resources/views/tables/controls-table.blade.php
@@ -1,0 +1,26 @@
+<!-- resources/views/filament/components/controls-table.blade.php -->
+@if($controls)
+
+    <table class="w-full text-sm text-left rtl:text-right text-black dark:text-gray-400">
+        <thead class="text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-700 dark:text-gray-400">
+        <tr>
+            <th scope="col" class="border px-4 py-2">Code</th>
+            <th scope="col" class="border px-4 py-2">Title</th>
+            <th scope="col" class="border px-4 py-2">description</th>
+            </tr>
+        </thead>
+        <tbody>
+
+        @foreach ($controls as $control)
+        <tr>
+            <td class="border px-4 py-2"> {{ $control->code }}</1234td>
+            <td class="border px-4 py-2">{{ $control->title }}</td>
+            <td class="border px-4 py-2"> {!! $control->description !!} </td>
+            </tr>
+        @endforeach
+
+        </tbody>
+        </table>
+@else
+    <p>No sub-controls.</p>
+@endif


### PR DESCRIPTION
## Summary
- add parent_control_id field migration
- support parent/child control relationships
- hide sub-controls from main controls list and allow selecting parent control
- show and manage sub-controls when viewing a control
- filter audit creation control choices to only root controls
- display sub-controls on audit item forms

## Testing
- `phpunit` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_683dbc50e42483259a37dc16dc2fb837