### PR TITLE
Add System resource linked to Vendors

### DIFF
--- a/app/Filament/Resources/SystemResource.php
+++ b/app/Filament/Resources/SystemResource.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Enums\YesNoNa;
+use App\Filament\Resources\SystemResource\Pages;
+use App\Models\System;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class SystemResource extends Resource
+{
+    protected static ?string $model = System::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-cpu-chip';
+
+    protected static ?string $navigationLabel = null;
+
+    public static function getNavigationLabel(): string
+    {
+        return __('system.navigation.label');
+    }
+
+    public static function getNavigationGroup(): string
+    {
+        return __('implementation.navigation.group');
+    }
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->columns(2)
+            ->schema([
+                Forms\Components\TextInput::make('title')
+                    ->label(__('system.form.title'))
+                    ->required(),
+                Forms\Components\Select::make('vendor_id')
+                    ->relationship('vendor', 'supplier')
+                    ->label(__('system.form.vendor'))
+                    ->searchable()
+                    ->preload()
+                    ->nullable(),
+                Forms\Components\Textarea::make('description')
+                    ->label(__('system.form.description'))
+                    ->columnSpanFull(),
+                Forms\Components\TextInput::make('logo_url')
+                    ->label(__('system.form.logo_url'))
+                    ->nullable(),
+                Forms\Components\TextInput::make('system_document_link')
+                    ->label(__('system.form.system_document_link'))
+                    ->nullable(),
+                Forms\Components\Select::make('security_password_policy_compliant')
+                    ->label(__('system.form.security_password_policy_compliant'))
+                    ->options(YesNoNa::class)
+                    ->default(YesNoNa::NA),
+                Forms\Components\Select::make('security_sso_connected')
+                    ->label(__('system.form.security_sso_connected'))
+                    ->options(YesNoNa::class)
+                    ->default(YesNoNa::NA),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('title')
+                    ->label(__('system.table.title'))
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('vendor.supplier')
+                    ->label(__('system.table.vendor')),
+                Tables\Columns\TextColumn::make('security_password_policy_compliant')
+                    ->label(__('system.table.security_password_policy_compliant'))
+                    ->badge(),
+                Tables\Columns\TextColumn::make('security_sso_connected')
+                    ->label(__('system.table.security_sso_connected'))
+                    ->badge(),
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListSystems::route('/'),
+            'create' => Pages\CreateSystem::route('/create'),
+            'edit' => Pages\EditSystem::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/SystemResource/Pages/CreateSystem.php
+++ b/app/Filament/Resources/SystemResource/Pages/CreateSystem.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\SystemResource\Pages;
+
+use App\Filament\Resources\SystemResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateSystem extends CreateRecord
+{
+    protected static string $resource = SystemResource::class;
+}

--- a/app/Filament/Resources/SystemResource/Pages/EditSystem.php
+++ b/app/Filament/Resources/SystemResource/Pages/EditSystem.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\SystemResource\Pages;
+
+use App\Filament\Resources\SystemResource;
+use Filament\Resources\Pages\EditRecord;
+
+class EditSystem extends EditRecord
+{
+    protected static string $resource = SystemResource::class;
+}

--- a/app/Filament/Resources/SystemResource/Pages/ListSystems.php
+++ b/app/Filament/Resources/SystemResource/Pages/ListSystems.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\SystemResource\Pages;
+
+use App\Filament\Resources\SystemResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListSystems extends ListRecords
+{
+    protected static string $resource = SystemResource::class;
+}

--- a/app/Filament/Resources/VendorResource.php
+++ b/app/Filament/Resources/VendorResource.php
@@ -4,6 +4,7 @@ namespace App\Filament\Resources;
 
 use App\Enums\YesNoNa;
 use App\Filament\Resources\VendorResource\Pages;
+use App\Filament\Resources\VendorResource\RelationManagers;
 use App\Models\Vendor;
 use Filament\Forms;
 use Filament\Forms\Form;
@@ -156,6 +157,13 @@ class VendorResource extends Resource
                     Tables\Actions\DeleteBulkAction::make(),
                 ]),
             ]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            RelationManagers\SystemsRelationManager::class,
+        ];
     }
 
     public static function getPages(): array

--- a/app/Filament/Resources/VendorResource/RelationManagers/SystemsRelationManager.php
+++ b/app/Filament/Resources/VendorResource/RelationManagers/SystemsRelationManager.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Filament\Resources\VendorResource\RelationManagers;
+
+use App\Enums\YesNoNa;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class SystemsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'systems';
+
+    protected static ?string $recordTitleAttribute = 'title';
+
+    public function form(Form $form): Form
+    {
+        return $form
+            ->columns(2)
+            ->schema([
+                Forms\Components\TextInput::make('title')
+                    ->required(),
+                Forms\Components\Textarea::make('description')
+                    ->columnSpanFull(),
+                Forms\Components\TextInput::make('logo_url'),
+                Forms\Components\TextInput::make('system_document_link'),
+                Forms\Components\Select::make('security_password_policy_compliant')
+                    ->options(YesNoNa::class)
+                    ->default(YesNoNa::NA),
+                Forms\Components\Select::make('security_sso_connected')
+                    ->options(YesNoNa::class)
+                    ->default(YesNoNa::NA),
+            ]);
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('title')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('security_password_policy_compliant')
+                    ->badge(),
+                Tables\Columns\TextColumn::make('security_sso_connected')
+                    ->badge(),
+            ])
+            ->headerActions([
+                Tables\Actions\CreateAction::make(),
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\DeleteAction::make(),
+            ]);
+    }
+}

--- a/app/Models/System.php
+++ b/app/Models/System.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\YesNoNa;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class System extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'title',
+        'vendor_id',
+        'description',
+        'logo_url',
+        'system_document_link',
+        'security_password_policy_compliant',
+        'security_sso_connected',
+    ];
+
+    protected $casts = [
+        'security_password_policy_compliant' => YesNoNa::class,
+        'security_sso_connected' => YesNoNa::class,
+    ];
+
+    public function vendor(): BelongsTo
+    {
+        return $this->belongsTo(Vendor::class);
+    }
+}

--- a/app/Models/Vendor.php
+++ b/app/Models/Vendor.php
@@ -5,6 +5,9 @@ namespace App\Models;
 use App\Enums\YesNoNa;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+use App\Models\System;
 
 class Vendor extends Model
 {
@@ -53,4 +56,9 @@ class Vendor extends Model
         'dpa_collected' => YesNoNa::class,
         'privacy_policy_collected' => YesNoNa::class,
     ];
+
+    public function systems(): \Illuminate\Database\Eloquent\Relations\HasMany
+    {
+        return $this->hasMany(System::class);
+    }
 }

--- a/database/migrations/2025_05_10_000000_create_systems_table.php
+++ b/database/migrations/2025_05_10_000000_create_systems_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use App\Enums\YesNoNa;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('systems', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->foreignId('vendor_id')->nullable()->constrained()->nullOnDelete();
+            $table->text('description')->nullable();
+            $table->string('logo_url')->nullable();
+            $table->string('system_document_link')->nullable();
+            $table->string('security_password_policy_compliant')->default(YesNoNa::NA);
+            $table->string('security_sso_connected')->default(YesNoNa::NA);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('systems');
+    }
+};

--- a/lang/en/navigation.php
+++ b/lang/en/navigation.php
@@ -21,6 +21,7 @@ return [
         'data_request' => 'Data Requests',
         'implementation' => 'Implementations',
         'vendor' => 'Vendors',
+        'system' => 'Systems',
         'role' => 'Roles',
     ],
 

--- a/lang/en/system.php
+++ b/lang/en/system.php
@@ -1,0 +1,26 @@
+<?php
+
+return [
+    'navigation' => [
+        'label' => 'Systems',
+        'group' => 'Foundations',
+    ],
+    'breadcrumb' => [
+        'title' => 'Systems',
+    ],
+    'form' => [
+        'title' => 'Title',
+        'vendor' => 'Vendor',
+        'description' => 'Description',
+        'logo_url' => 'Logo URL',
+        'system_document_link' => 'System Document Link',
+        'security_password_policy_compliant' => 'Password Policy Compliant',
+        'security_sso_connected' => 'SSO Connected',
+    ],
+    'table' => [
+        'title' => 'Title',
+        'vendor' => 'Vendor',
+        'security_password_policy_compliant' => 'Password Policy Compliant',
+        'security_sso_connected' => 'SSO Connected',
+    ],
+];


### PR DESCRIPTION
## Summary
- create migration and model for `systems`
- add relationship between Vendors and Systems
- implement SystemResource with Filament forms and tables
- allow managing Systems from VendorResource via relation manager
- add English translations and navigation label for Systems

## Testing
- `./vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_683ee08d3cf48325868c5cc93be0f018