### PR TITLE
Add control status tracking

### DIFF
--- a/app/Enums/ControlStatus.php
+++ b/app/Enums/ControlStatus.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Enums;
+
+use Filament\Support\Contracts\HasColor;
+use Filament\Support\Contracts\HasLabel;
+
+enum ControlStatus: string implements HasColor, HasLabel
+{
+    case NOT_STARTED = 'Not Started';
+    case IN_PROGRESS = 'In Progress';
+    case COMPLETED = 'Completed';
+    case UNKNOWN = 'Unknown';
+
+    public function getLabel(): ?string
+    {
+        return match ($this) {
+            self::NOT_STARTED => __('enums.control_status.not_started'),
+            self::IN_PROGRESS => __('enums.control_status.in_progress'),
+            self::COMPLETED => __('enums.control_status.completed'),
+            self::UNKNOWN => __('enums.control_status.unknown'),
+        };
+    }
+
+    public function getColor(): string|array|null
+    {
+        return match ($this) {
+            self::NOT_STARTED => 'danger',
+            self::IN_PROGRESS => 'warning',
+            self::COMPLETED => 'success',
+            self::UNKNOWN => 'gray',
+        };
+    }
+}

--- a/app/Filament/Resources/AuditItemResource/Pages/EditAuditItem.php
+++ b/app/Filament/Resources/AuditItemResource/Pages/EditAuditItem.php
@@ -19,6 +19,7 @@ use Filament\Forms\Components\Placeholder;
 use Filament\Forms\Components\RichEditor;
 use Filament\Forms\Components\ToggleButtons;
 use Filament\Forms\Form;
+use Filament\Infolists\Components\TextEntry;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\EditRecord;
 use Illuminate\Support\Facades\Mail;
@@ -137,6 +138,9 @@ class EditAuditItem extends EditRecord
             ->schema([
                 Forms\Components\Section::make('Item Information')
                     ->schema([
+                        Placeholder::make('control_status')
+                            ->label('Control Status')
+                            ->content(fn(AuditItem $record): string => $record->auditable->status->value),
                         Placeholder::make('control_code')
                             ->label('Code')
                             ->content(fn(AuditItem $record): ?string => $record->auditable->code),

--- a/app/Filament/Resources/AuditResource/RelationManagers/AuditItemRelationManager.php
+++ b/app/Filament/Resources/AuditResource/RelationManagers/AuditItemRelationManager.php
@@ -26,23 +26,26 @@ class AuditItemRelationManager extends RelationManager
             ->schema([
                 Forms\Components\Section::make('Control Information')
                     ->schema([
+                        Placeholder::make('control_status')
+                            ->label('Control Status')
+                            ->content(fn(AuditItem $record): string => $record->control->status),
                         Placeholder::make('control_code')
                             ->label('Control Code')
-                            ->content(fn (AuditItem $record): string => $record->control->code),
+                            ->content(fn(AuditItem $record): string => $record->control->code),
                         Placeholder::make('control_title')
                             ->label('Control Title')
-                            ->content(fn (AuditItem $record): string => $record->control->title),
+                            ->content(fn(AuditItem $record): string => $record->control->title),
                         Placeholder::make('control_desc')
                             ->label('Control Description')
-                            ->content(fn (AuditItem $record): HtmlString => new HtmlString(optional($record->control)->description ?? ''))
+                            ->content(fn(AuditItem $record): HtmlString => new HtmlString(optional($record->control)->description ?? ''))
                             ->columnSpanFull(),
                         Placeholder::make('control_discussion')
                             ->label('Control Discussion')
-                            ->content(fn (AuditItem $record): HtmlString => new HtmlString(optional($record->control)->discussion ?? ''))
+                            ->content(fn(AuditItem $record): HtmlString => new HtmlString(optional($record->control)->discussion ?? ''))
                             ->columnSpanFull(),
                         Placeholder::make('sub_controls')
                             ->label('Sub Controls')
-                            ->content(fn (AuditItem $record): HtmlString => new HtmlString($this->subControlsList($record)))
+                            ->content(fn(AuditItem $record): HtmlString => new HtmlString($this->subControlsList($record)))
                             ->columnSpanFull(),
 
                     ])->columns(2)->collapsible(true),
@@ -80,13 +83,13 @@ class AuditItemRelationManager extends RelationManager
                         // supported in Filament - potentially in v4.x
                         Placeholder::make('control.implementations')
                             ->label('Documented Implementations')
-                            ->content(fn (AuditItem $record): HtmlString => new HtmlString($this->implementationsTable($record)))
+                            ->content(fn(AuditItem $record): HtmlString => new HtmlString($this->implementationsTable($record)))
                             ->columnSpanFull()
                             ->hintIcon('heroicon-m-question-mark-circle', tooltip: 'Implementations that a related to this control.'),
 
                         Placeholder::make('data_requests')
                             ->label('Data Requests Issued')
-                            ->content(fn (AuditItem $record): HtmlString => new HtmlString($this->dataRequestsTable($record)))
+                            ->content(fn(AuditItem $record): HtmlString => new HtmlString($this->dataRequestsTable($record)))
                             ->columnSpanFull()
                             ->hintIcon('heroicon-m-question-mark-circle', tooltip: 'Data Requests that have been issued.'),
 
@@ -113,11 +116,11 @@ class AuditItemRelationManager extends RelationManager
         // Loop through dataRequests and generate table rows
         foreach ($dataRequests as $request) {
             $html .= '<tr>';
-            $html .= '<td class="border px-4 py-2">'.e($request->code).'</td>';
-            $html .= '<td class="border px-4 py-2">'.'<a target="_blank"   href='.
-                route('filament.app.resources.implementations.view', $request->id).
-                '>'.e($request->title).'</a></td>';
-            $html .= '<td class="border px-4 py-2">'.$request->details.'</td>';
+            $html .= '<td class="border px-4 py-2">' . e($request->code) . '</td>';
+            $html .= '<td class="border px-4 py-2">' . '<a target="_blank"   href=' .
+                route('filament.app.resources.implementations.view', $request->id) .
+                '>' . e($request->title) . '</a></td>';
+            $html .= '<td class="border px-4 py-2">' . $request->details . '</td>';
             $html .= '</tr>';
         }
 
@@ -148,19 +151,19 @@ class AuditItemRelationManager extends RelationManager
         // Loop through dataRequests and generate table rows
         foreach ($dataRequests as $request) {
             $html .= '<tr>';
-            $html .= '<td class="border px-4 py-2">'.e($request->details).'</td>';
+            $html .= '<td class="border px-4 py-2">' . e($request->details) . '</td>';
             $html .= '<td class="border px-4 py-2">';
             foreach ($request->responses as $r) {
-                $html .= '<div>'.$r->response.'</div>';
+                $html .= '<div>' . $r->response . '</div>';
                 if (isset($r->attachments)) {
                     foreach ($r->attachments as $attachment) {
-                        $html .= '***<a href="#">'.$attachment->description.'</a>';
+                        $html .= '***<a href="#">' . $attachment->description . '</a>';
                     }
                 }
             }
 
             $html .= '</td>';
-            $html .= '<td class="border px-4 py-2">'.$request->status.'</td>';
+            $html .= '<td class="border px-4 py-2">' . $request->status . '</td>';
             $html .= '</tr>';
         }
 
@@ -178,7 +181,7 @@ class AuditItemRelationManager extends RelationManager
         if ($subs instanceof \Illuminate\Support\Collection && $subs->isNotEmpty()) {
             $list = '<ul class="list-disc ml-6">';
             foreach ($subs as $sub) {
-                $list .= '<li>'.e($sub->code).' - '.e($sub->title).'</li>';
+                $list .= '<li>' . e($sub->code) . ' - ' . e($sub->title) . '</li>';
             }
             $list .= '</ul>';
             return $list;
@@ -212,10 +215,9 @@ class AuditItemRelationManager extends RelationManager
             ->actions([
                 Tables\Actions\EditAction::make()
                     ->label('Assess control')
-                    ->visible(fn (AuditItem $record): bool => $record->audit->status === WorkflowStatus::INPROGRESS)
-                    ->url(fn (AuditItem $record): string => route('filament.app.resources.audit-items.edit', ['record' => $record->id])),
+                    ->visible(fn(AuditItem $record): bool => $record->audit->status === WorkflowStatus::INPROGRESS)
+                    ->url(fn(AuditItem $record): string => route('filament.app.resources.audit-items.edit', ['record' => $record->id])),
             ])
             ->bulkActions([]);
-
     }
 }

--- a/app/Filament/Resources/ControlResource.php
+++ b/app/Filament/Resources/ControlResource.php
@@ -15,6 +15,7 @@ use App\Models\Control;
 use App\Models\Standard;
 use Exception;
 use Filament\Forms;
+use Filament\Forms\Components\ToggleButtons;
 use Filament\Forms\Form;
 use Filament\Infolists\Components\Section;
 use Filament\Infolists\Components\TextEntry;
@@ -67,6 +68,11 @@ class ControlResource extends Resource
         return $form
             ->columns(3)
             ->schema([
+                ToggleButtons::make('status')
+                    ->label('Status')
+                    ->options(ControlStatus::class)
+                    ->default(ControlStatus::NOT_STARTED)
+                    ->grouped(),
                 Forms\Components\TextInput::make('code')
                     ->required()
                     ->hintIcon('heroicon-m-question-mark-circle', tooltip: __('control.form.code.tooltip'))
@@ -88,11 +94,6 @@ class ControlResource extends Resource
                     ->searchable()
                     ->preload()
                     ->nullable(),
-                Forms\Components\Select::make('status')
-                    ->options(ControlStatus::class)
-                    ->default(ControlStatus::NOT_STARTED)
-                    ->required()
-                    ->native(false),
                 Forms\Components\Select::make('enforcement')
                     ->options(ControlEnforcementCategory::class)
                     ->hintIcon('heroicon-m-question-mark-circle', tooltip: __('control.form.enforcement.tooltip'))
@@ -155,40 +156,14 @@ class ControlResource extends Resource
                     ->label(__('control.table.columns.standard'))
                     ->wrap()
                     ->sortable(),
-                Tables\Columns\TextColumn::make('type')
-                    ->label(__('control.table.columns.type'))
-                    ->sortable(),
-                Tables\Columns\TextColumn::make('category')
-                    ->label(__('control.table.columns.category'))
-                    ->sortable(),
-                Tables\Columns\TextColumn::make('enforcement')
-                    ->label(__('control.table.columns.enforcement'))
-                    ->sortable(),
-                Tables\Columns\TextColumn::make('LatestAuditEffectiveness')
-                    ->label(__('control.table.columns.effectiveness'))
-                    ->badge()
-                    ->sortable()
-                    ->default(function (Control $record) {
-                        return $record->getEffectiveness();
-                    }),
-                Tables\Columns\TextColumn::make('applicability')
-                    ->label(__('control.table.columns.applicability'))
-                    ->sortable()
-                    ->badge(),
                 Tables\Columns\TextColumn::make('status')
                     ->label(__('control.table.columns.status'))
                     ->badge()
                     ->sortable(),
-                Tables\Columns\TextColumn::make('completion_percentage')
-                    ->label(__('control.table.columns.progress'))
-                    ->getStateUsing(fn(Control $record) => $record->completion_percentage.'%')
-                    ->visible(fn(Control $record) => $record->subControls()->count() > 0),
                 Tables\Columns\TextColumn::make('LatestAuditDate')
                     ->label(__('control.table.columns.assessed'))
                     ->sortable()
-                    ->default(function (Control $record) {
-                        return $record->getEffectivenessDate();
-                    }),
+                    ->getStateUsing(fn(Control $record) => $record->getEffectivenessDate()),
                 Tables\Columns\TextColumn::make('created_at')
                     ->label(__('control.table.columns.created_at'))
                     ->dateTime()
@@ -268,7 +243,10 @@ class ControlResource extends Resource
                 Section::make(__('control.infolist.section_title'))
                     ->columns(3)
                     ->schema([
-                        TextEntry::make('title')->columnSpanFull(),
+                        TextEntry::make('status')
+                            ->label(__('control.table.columns.progress'))
+                            ->badge(),
+                        TextEntry::make('title')->columnSpan(2),
                         TextEntry::make('code'),
                         TextEntry::make('effectiveness')
                             ->default(function (Control $record) {
@@ -277,11 +255,6 @@ class ControlResource extends Resource
                         TextEntry::make('type')->badge(),
                         TextEntry::make('category')->badge(),
                         TextEntry::make('enforcement')->badge(),
-                        TextEntry::make('status')->badge(),
-                        TextEntry::make('completion_percentage')
-                            ->label(__('control.table.columns.progress'))
-                            ->default(fn (Control $record) => $record->completion_percentage.'%')
-                            ->visible(fn (Control $record) => $record->subControls()->count() > 0),
                         TextEntry::make('lastAuditDate')
                             ->default(function (Control $record) {
                                 return $record->getEffectivenessDate();

--- a/app/Filament/Resources/ControlResource.php
+++ b/app/Filament/Resources/ControlResource.php
@@ -11,6 +11,7 @@ use App\Enums\Effectiveness;
 use App\Enums\ControlStatus;
 use App\Filament\Resources\ControlResource\Pages;
 use App\Filament\Resources\ControlResource\RelationManagers;
+use App\Filament\Resources\ControlResource\RelationManagers\SubControlRelationManager;
 use App\Models\Control;
 use App\Models\Standard;
 use Exception;
@@ -22,6 +23,7 @@ use Filament\Infolists\Components\TextEntry;
 use Filament\Infolists\Infolist;
 use Filament\Resources\Resource;
 use Filament\Tables;
+use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Builder;
@@ -155,15 +157,16 @@ class ControlResource extends Resource
                 Tables\Columns\TextColumn::make('standard.name')
                     ->label(__('control.table.columns.standard'))
                     ->wrap()
+                    ->sortable()
+                    ->hiddenOn(SubControlRelationManager::class),
+                TextColumn::make('applicability')
+                    ->label('Applicability')
+                    ->badge()
                     ->sortable(),
                 Tables\Columns\TextColumn::make('status')
                     ->label(__('control.table.columns.status'))
                     ->badge()
                     ->sortable(),
-                Tables\Columns\TextColumn::make('LatestAuditDate')
-                    ->label(__('control.table.columns.assessed'))
-                    ->sortable()
-                    ->getStateUsing(fn(Control $record) => $record->getEffectivenessDate()),
                 Tables\Columns\TextColumn::make('created_at')
                     ->label(__('control.table.columns.created_at'))
                     ->dateTime()

--- a/app/Filament/Resources/ControlResource/Pages/EditControl.php
+++ b/app/Filament/Resources/ControlResource/Pages/EditControl.php
@@ -5,6 +5,8 @@ namespace App\Filament\Resources\ControlResource\Pages;
 use App\Filament\Resources\ControlResource;
 use Filament\Actions;
 use Filament\Resources\Pages\EditRecord;
+use Livewire\Attributes\On;
+
 
 class EditControl extends EditRecord
 {

--- a/app/Filament/Resources/ControlResource/Pages/ViewControl.php
+++ b/app/Filament/Resources/ControlResource/Pages/ViewControl.php
@@ -2,6 +2,8 @@
 
 namespace App\Filament\Resources\ControlResource\Pages;
 
+use Livewire\Attributes\On;
+
 use App\Filament\Resources\ControlResource;
 use App\Http\Controllers\AiController;
 use Filament\Actions;
@@ -33,5 +35,12 @@ class ViewControl extends ViewRecord
     public function getTitle(): string
     {
         return 'Control';
+    }
+
+    #[On('refresh')]
+    public function refreshPage(): void
+    {
+        // re-query the model + rebuild every form component
+        $this->refreshFormData(['status']);
     }
 }

--- a/app/Filament/Resources/ControlResource/RelationManagers/SubControlRelationManager.php
+++ b/app/Filament/Resources/ControlResource/RelationManagers/SubControlRelationManager.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\ControlResource\RelationManagers;
 use AmidEsfahani\FilamentTinyEditor\TinyEditor;
 use App\Enums\Applicability;
 use App\Enums\ControlStatus;
+use App\Filament\Resources\ControlResource;
 use App\Models\Control;
 use Filament\Actions\EditAction;
 use Filament\Forms;
@@ -71,16 +72,8 @@ class SubControlRelationManager extends RelationManager
 
     public function table(Table $table): Table
     {
-        return $table
-            ->defaultSort('code', 'asc')
-            ->columns([
-                Tables\Columns\TextColumn::make('code')->searchable()->sortable(),
-                Tables\Columns\TextColumn::make('title')->searchable()->sortable()->wrap(),
-                Tables\Columns\TextColumn::make('status')->badge(),
-                Tables\Columns\TextColumn::make('description')->html()
-                    ->wrap()
-                    ->limit(300)
-            ])
+        return ControlResource::table($table)
+            ->description('If this control has any associated sub-controls, they have to be completed too.')
             ->headerActions([
                 Tables\Actions\CreateAction::make()
                     ->using(function (array $data, RelationManager $livewire) {

--- a/app/Filament/Resources/ControlResource/RelationManagers/SubControlRelationManager.php
+++ b/app/Filament/Resources/ControlResource/RelationManagers/SubControlRelationManager.php
@@ -8,11 +8,14 @@ use App\Enums\ControlStatus;
 use App\Models\Control;
 use Filament\Actions\EditAction;
 use Filament\Forms;
+use Filament\Forms\Components\ToggleButtons;
+use Livewire\Component;
 use Filament\Forms\Form;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\Client\Request;
 
 class SubControlRelationManager extends RelationManager
 {
@@ -22,6 +25,13 @@ class SubControlRelationManager extends RelationManager
     {
         return $form
             ->schema([
+                ToggleButtons::make('status')
+                    ->label('Status')
+                    ->helperText('Updating a status for a subcontrol, will also impact the parent control')
+                    ->options(ControlStatus::class)
+                    ->default(ControlStatus::NOT_STARTED)
+                    ->columnSpanFull()
+                    ->grouped(),
                 Forms\Components\TextInput::make('code')
                     ->required()
                     ->maxLength(255)
@@ -33,12 +43,6 @@ class SubControlRelationManager extends RelationManager
                     ->enum(Applicability::class)
                     ->options(Applicability::class)
                     ->hintIcon('heroicon-m-question-mark-circle', tooltip: 'Select the relevance of this standard to your organization.')
-                    ->native(false),
-                Forms\Components\Select::make('status')
-                    ->default(ControlStatus::NOT_STARTED)
-                    ->required()
-                    ->enum(ControlStatus::class)
-                    ->options(ControlStatus::class)
                     ->native(false),
                 Forms\Components\TextInput::make('title')
                     ->required()
@@ -88,7 +92,11 @@ class SubControlRelationManager extends RelationManager
             ])
             ->actions([
                 Tables\Actions\ViewAction::make()->hiddenLabel()->slideOver(),
-                Tables\Actions\EditAction::make()->slideOver(),
+                Tables\Actions\EditAction::make()
+                    ->slideOver()
+                    ->after(function (Component $livewire) {
+                        $livewire->dispatch('refresh');
+                    }),
                 Tables\Actions\DeleteAction::make(),
             ]);
     }

--- a/app/Filament/Resources/ControlResource/RelationManagers/SubControlRelationManager.php
+++ b/app/Filament/Resources/ControlResource/RelationManagers/SubControlRelationManager.php
@@ -4,6 +4,7 @@ namespace App\Filament\Resources\ControlResource\RelationManagers;
 
 use AmidEsfahani\FilamentTinyEditor\TinyEditor;
 use App\Enums\Applicability;
+use App\Enums\ControlStatus;
 use App\Models\Control;
 use Filament\Actions\EditAction;
 use Filament\Forms;
@@ -32,6 +33,12 @@ class SubControlRelationManager extends RelationManager
                     ->enum(Applicability::class)
                     ->options(Applicability::class)
                     ->hintIcon('heroicon-m-question-mark-circle', tooltip: 'Select the relevance of this standard to your organization.')
+                    ->native(false),
+                Forms\Components\Select::make('status')
+                    ->default(ControlStatus::NOT_STARTED)
+                    ->required()
+                    ->enum(ControlStatus::class)
+                    ->options(ControlStatus::class)
                     ->native(false),
                 Forms\Components\TextInput::make('title')
                     ->required()
@@ -65,6 +72,7 @@ class SubControlRelationManager extends RelationManager
             ->columns([
                 Tables\Columns\TextColumn::make('code')->searchable()->sortable(),
                 Tables\Columns\TextColumn::make('title')->searchable()->sortable()->wrap(),
+                Tables\Columns\TextColumn::make('status')->badge(),
                 Tables\Columns\TextColumn::make('description')->html()
                     ->wrap()
                     ->limit(300)

--- a/app/Filament/Resources/ImplementationResource/RelationManagers/ControlsRelationManager.php
+++ b/app/Filament/Resources/ImplementationResource/RelationManagers/ControlsRelationManager.php
@@ -7,6 +7,7 @@ use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use App\Enums\ControlStatus;
+use App\Filament\Resources\ControlResource;
 
 class ControlsRelationManager extends RelationManager
 {
@@ -14,30 +15,7 @@ class ControlsRelationManager extends RelationManager
 
     public function table(Table $table): Table
     {
-        return $table
-            ->recordTitleAttribute('title')
-            ->columns([
-                Tables\Columns\TextColumn::make('code')
-                    ->sortable()
-                    ->searchable()
-                    ->wrap(),
-                Tables\Columns\TextColumn::make('standard.name')
-                    ->sortable()
-                    ->searchable()
-                    ->wrap(),
-                Tables\Columns\TextColumn::make('title')
-                    ->sortable()
-                    ->wrap(),
-                Tables\Columns\TextColumn::make('status')
-                    ->badge(),
-                Tables\Columns\TextColumn::make('completion_percentage')
-                    ->label(__('control.table.columns.progress'))
-                    ->getStateUsing(fn($record) => $record->completion_percentage.'%')
-                    ->visible(fn($record) => $record->subControls()->count() > 0),
-            ])
-            ->filters([
-                //
-            ])
+        return ControlResource::table($table)
             ->headerActions([
                 Tables\Actions\CreateAction::make(),
                 Tables\Actions\AttachAction::make()
@@ -54,7 +32,7 @@ class ControlsRelationManager extends RelationManager
             ])
             ->actions([
                 Tables\Actions\ViewAction::make()
-                    ->url(fn ($record) => route('filament.app.resources.controls.view', $record)),
+                    ->url(fn($record) => route('filament.app.resources.controls.view', $record)),
 
             ])
             ->bulkActions([

--- a/app/Filament/Resources/ImplementationResource/RelationManagers/ControlsRelationManager.php
+++ b/app/Filament/Resources/ImplementationResource/RelationManagers/ControlsRelationManager.php
@@ -6,6 +6,7 @@ use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
+use App\Enums\ControlStatus;
 
 class ControlsRelationManager extends RelationManager
 {
@@ -27,6 +28,12 @@ class ControlsRelationManager extends RelationManager
                 Tables\Columns\TextColumn::make('title')
                     ->sortable()
                     ->wrap(),
+                Tables\Columns\TextColumn::make('status')
+                    ->badge(),
+                Tables\Columns\TextColumn::make('completion_percentage')
+                    ->label(__('control.table.columns.progress'))
+                    ->getStateUsing(fn($record) => $record->completion_percentage.'%')
+                    ->visible(fn($record) => $record->subControls()->count() > 0),
             ])
             ->filters([
                 //

--- a/app/Filament/Resources/ProgramResource/RelationManagers/ControlsRelationManager.php
+++ b/app/Filament/Resources/ProgramResource/RelationManagers/ControlsRelationManager.php
@@ -7,6 +7,7 @@ use Filament\Forms\Form;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables;
 use Filament\Tables\Table;
+use App\Enums\ControlStatus;
 
 class ControlsRelationManager extends RelationManager
 {
@@ -31,6 +32,12 @@ class ControlsRelationManager extends RelationManager
                 Tables\Columns\TextColumn::make('title')
                     ->searchable()
                     ->sortable(),
+                Tables\Columns\TextColumn::make('status')
+                    ->badge(),
+                Tables\Columns\TextColumn::make('completion_percentage')
+                    ->label(__('control.table.columns.progress'))
+                    ->getStateUsing(fn($record) => $record->completion_percentage.'%')
+                    ->visible(fn($record) => $record->subControls()->count() > 0),
             ])
             ->filters([
                 //

--- a/app/Filament/Resources/StandardResource/RelationManagers/ControlsRelationManager.php
+++ b/app/Filament/Resources/StandardResource/RelationManagers/ControlsRelationManager.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources\StandardResource\RelationManagers;
 
 use App\Enums\Applicability;
+use App\Enums\ControlStatus;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Resources\RelationManagers\RelationManager;
@@ -29,6 +30,12 @@ class ControlsRelationManager extends RelationManager
                     ->enum(Applicability::class)
                     ->options(Applicability::class)
                     ->hintIcon('heroicon-m-question-mark-circle', tooltip: 'Select the relevance of this standard to your organization.')
+                    ->native(false),
+                Forms\Components\Select::make('status')
+                    ->default(ControlStatus::NOT_STARTED)
+                    ->required()
+                    ->enum(ControlStatus::class)
+                    ->options(ControlStatus::class)
                     ->native(false),
                 Forms\Components\TextInput::make('title')
                     ->required()
@@ -72,6 +79,12 @@ class ControlsRelationManager extends RelationManager
                     ->wrap()
                     ->limit(300)
                     ->searchable(),
+                Tables\Columns\TextColumn::make('status')
+                    ->badge(),
+                Tables\Columns\TextColumn::make('completion_percentage')
+                    ->label(__('control.table.columns.progress'))
+                    ->getStateUsing(fn($record) => $record->completion_percentage.'%')
+                    ->visible(fn($record) => $record->subControls()->count() > 0),
             ])
             ->filters([
                 //

--- a/app/Models/Control.php
+++ b/app/Models/Control.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Enums\Applicability;
+use App\Enums\ControlStatus;
 use App\Enums\ControlCategory;
 use App\Enums\ControlEnforcementCategory;
 use App\Enums\ControlType;
@@ -14,6 +15,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use App\Models\Program;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -23,7 +25,7 @@ use Illuminate\Support\Carbon;
  * Class Control
  *
  * @property int $id
- * @property Applicability $status
+ * @property ControlStatus $status
  * @property Effectiveness $effectiveness
  * @property ControlType $type
  * @property ControlCategory $category
@@ -69,7 +71,7 @@ class Control extends Model
      */
     protected $casts = [
         'id' => 'integer',
-        'status' => Applicability::class,
+        'status' => ControlStatus::class,
         'effectiveness' => Effectiveness::class,
         'type' => ControlType::class,
         'category' => ControlCategory::class,
@@ -183,5 +185,41 @@ class Control extends Model
     public function programs(): BelongsToMany
     {
         return $this->belongsToMany(Program::class);
+    }
+
+    public function getCompletionPercentageAttribute(): int
+    {
+        $total = $this->subControls()->count();
+        if ($total === 0) {
+            return $this->status === ControlStatus::COMPLETED ? 100 : 0;
+        }
+
+        $completed = $this->subControls()->where('status', ControlStatus::COMPLETED)->count();
+
+        return (int) round(($completed / $total) * 100);
+    }
+
+    protected static function booted()
+    {
+        static::saved(function (Control $control) {
+            if ($control->parent) {
+                $parent = $control->parent;
+
+                if ($control->status !== ControlStatus::COMPLETED) {
+                    if ($parent->status !== ControlStatus::IN_PROGRESS) {
+                        $parent->status = ControlStatus::IN_PROGRESS;
+                        $parent->save();
+                    }
+                } else {
+                    if ($parent->subControls()->where('status', '!=', ControlStatus::COMPLETED)->count() === 0) {
+                        $parent->status = ControlStatus::COMPLETED;
+                        $parent->save();
+                    } else {
+                        $parent->status = ControlStatus::IN_PROGRESS;
+                        $parent->save();
+                    }
+                }
+            }
+        });
     }
 }

--- a/app/Models/Control.php
+++ b/app/Models/Control.php
@@ -187,18 +187,6 @@ class Control extends Model
         return $this->belongsToMany(Program::class);
     }
 
-    public function getCompletionPercentageAttribute(): int
-    {
-        $total = $this->subControls()->count();
-        if ($total === 0) {
-            return $this->status === ControlStatus::COMPLETED ? 100 : 0;
-        }
-
-        $completed = $this->subControls()->where('status', ControlStatus::COMPLETED)->count();
-
-        return (int) round(($completed / $total) * 100);
-    }
-
     protected static function booted()
     {
         static::saved(function (Control $control) {

--- a/database/factories/ControlFactory.php
+++ b/database/factories/ControlFactory.php
@@ -7,6 +7,7 @@ use App\Enums\ControlCategory;
 use App\Enums\ControlEnforcementCategory;
 use App\Enums\ControlType;
 use App\Enums\Effectiveness;
+use App\Enums\ControlStatus;
 use App\Models\Control;
 use App\Models\Standard;
 use Illuminate\Database\Eloquent\Factories\Factory;
@@ -28,6 +29,7 @@ class ControlFactory extends Factory
             'enforcement' => $this->faker->randomElement(ControlEnforcementCategory::class),
             'effectiveness' => $this->faker->randomElement(Effectiveness::class),
             'applicability' => $this->faker->randomElement(Applicability::class),
+            'status' => $this->faker->randomElement(ControlStatus::class),
             'created_at' => Carbon::now(),
             'updated_at' => Carbon::now(),
 

--- a/database/migrations/2025_05_21_000001_add_status_to_controls_table.php
+++ b/database/migrations/2025_05_21_000001_add_status_to_controls_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use App\Enums\ControlStatus;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('controls', function (Blueprint $table) {
+            $table->string('status')->default(ControlStatus::NOT_STARTED)->after('applicability');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('controls', function (Blueprint $table) {
+            $table->dropColumn('status');
+        });
+    }
+};

--- a/lang/en/control.php
+++ b/lang/en/control.php
@@ -52,6 +52,8 @@ return [
             'enforcement' => 'Enforcement',
             'effectiveness' => 'Effectiveness',
             'applicability' => 'Applicability',
+            'status' => 'Status',
+            'progress' => 'Progress',
             'assessed' => 'Last Assessed',
             'created_at' => 'Created At',
             'updated_at' => 'Updated At',
@@ -63,6 +65,7 @@ return [
             'category' => 'Category',
             'enforcement' => 'Enforcement',
             'applicability' => 'Applicability',
+            'status' => 'Status',
         ],
     ],
     'infolist' => [

--- a/lang/en/enums.php
+++ b/lang/en/enums.php
@@ -7,6 +7,12 @@ return [
         'completed' => 'Completed',
         'unknown' => 'Unknown',
     ],
+    'control_status' => [
+        'not_started' => 'Not Started',
+        'in_progress' => 'In Progress',
+        'completed' => 'Completed',
+        'unknown' => 'Unknown',
+    ],
     'effectiveness' => [
         'effective' => 'Effective',
         'partial' => 'Partially Effective',


### PR DESCRIPTION
## Summary
- introduce `ControlStatus` enum
- store status on controls with migration and model casts
- track completion progress of sub-controls
- display control status and progress across resources
- allow setting status on controls and sub-controls
- update factories and translations

## Testing
- `composer test` *(fails: `composer` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68445cbdeb48832590c7da9cbf53386e