### PR TITLE
Add recurring implementation tasks

### DIFF
--- a/app/Enums/TaskRecurrence.php
+++ b/app/Enums/TaskRecurrence.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Enums;
+
+use Filament\Support\Contracts\HasLabel;
+
+enum TaskRecurrence: string implements HasLabel
+{
+    case NONE = 'None';
+    case MONTHLY = 'Monthly';
+    case QUARTERLY = 'Quarterly';
+    case YEARLY = 'Yearly';
+
+    public function getLabel(): ?string
+    {
+        return match ($this) {
+            self::NONE => 'None',
+            self::MONTHLY => 'Monthly',
+            self::QUARTERLY => 'Quarterly',
+            self::YEARLY => 'Yearly',
+        };
+    }
+}

--- a/app/Enums/TaskStatus.php
+++ b/app/Enums/TaskStatus.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Enums;
+
+use Filament\Support\Contracts\HasColor;
+use Filament\Support\Contracts\HasLabel;
+
+enum TaskStatus: string implements HasLabel, HasColor
+{
+    case PENDING = 'Pending';
+    case COMPLETED = 'Completed';
+
+    public function getLabel(): ?string
+    {
+        return match ($this) {
+            self::PENDING => 'Pending',
+            self::COMPLETED => 'Completed',
+        };
+    }
+
+    public function getColor(): string|array|null
+    {
+        return match ($this) {
+            self::PENDING => 'primary',
+            self::COMPLETED => 'success',
+        };
+    }
+}

--- a/app/Filament/Pages/ToDo.php
+++ b/app/Filament/Pages/ToDo.php
@@ -4,6 +4,8 @@ namespace App\Filament\Pages;
 
 use App\Enums\ResponseStatus;
 use App\Models\DataRequestResponse;
+use App\Models\ImplementationTask;
+use App\Enums\TaskStatus;
 use Filament\Pages\Page;
 use Filament\Tables;
 use Filament\Tables\Actions\Action;
@@ -26,7 +28,7 @@ class ToDo extends Page implements Tables\Contracts\HasTable
 
     public static function getNavigationBadge(): ?string
     {
-        $count = auth()->user()->openTodos()->count();
+        $count = auth()->user()->openTodos()->count() + \App\Models\ImplementationTask::where('status', \App\Enums\TaskStatus::PENDING)->count();
 
         if ($count > 99) {
             return '99+';

--- a/app/Filament/Pages/ToDo.php
+++ b/app/Filament/Pages/ToDo.php
@@ -2,23 +2,11 @@
 
 namespace App\Filament\Pages;
 
-use App\Enums\ResponseStatus;
-use App\Models\DataRequestResponse;
-use App\Models\ImplementationTask;
-use App\Enums\TaskStatus;
 use Filament\Pages\Page;
-use Filament\Tables;
-use Filament\Tables\Actions\Action;
-use Filament\Tables\Columns\TextColumn;
-use Filament\Tables\Concerns\InteractsWithTable;
-use Illuminate\Database\Eloquent\Builder;
 
-class ToDo extends Page implements Tables\Contracts\HasTable
+class ToDo extends Page
 {
-    use InteractsWithTable;
-
     protected static ?string $navigationIcon = 'heroicon-o-check-circle';
-
     protected static string $view = 'filament.pages.to-do';
 
     public static function getNavigationLabel(): string
@@ -28,51 +16,15 @@ class ToDo extends Page implements Tables\Contracts\HasTable
 
     public static function getNavigationBadge(): ?string
     {
-        $count = auth()->user()->openTodos()->count() + \App\Models\ImplementationTask::where('status', \App\Enums\TaskStatus::PENDING)->count();
+        $pendingResponses = auth()->user()->openTodos()->count();
+        $pendingTasks     = \App\Models\ImplementationTask::where('status', \App\Enums\TaskStatus::PENDING)->count();
+
+        $count = $pendingResponses + $pendingTasks;
 
         if ($count > 99) {
             return '99+';
-        } elseif ($count > 0) {
-            return $count;
         }
 
-        return null;
-
-    }
-
-    protected function getTableQuery(): Builder
-    {
-        return DataRequestResponse::query()->where('requestee_id', auth()->id());
-    }
-
-    protected function getTableColumns(): array
-    {
-        return [
-            TextColumn::make('id')->label('ID')->sortable(),
-            TextColumn::make('dataRequest.audit.title')->label('Audit'),
-            TextColumn::make('dataRequest.details')->label('Requested Information')->html()->limit(100),
-            TextColumn::make('due_at')->label('Due At'),
-            TextColumn::make('status')->label('Status'),
-        ];
-    }
-
-    protected function getTableFilters(): array
-    {
-        return [
-            Tables\Filters\SelectFilter::make('status')
-                ->label('Show Responded')
-                ->multiple()
-                ->options(ResponseStatus::class)
-                ->default(['Pending', 'Rejected']),
-        ];
-    }
-
-    protected function getTableActions(): array
-    {
-        return [
-            Action::make('view')
-                ->label('Respond')
-                ->url(fn (DataRequestResponse $record): string => route('filament.app.resources.data-request-responses.edit', $record)),
-        ];
+        return $count ?: null;
     }
 }

--- a/app/Filament/Resources/ControlResource.php
+++ b/app/Filament/Resources/ControlResource.php
@@ -4,6 +4,7 @@ namespace App\Filament\Resources;
 
 use AmidEsfahani\FilamentTinyEditor\TinyEditor;
 use App\Enums\Applicability;
+use Filament\Tables\Columns\ToggleColumn;
 use App\Enums\ControlCategory;
 use App\Enums\ControlEnforcementCategory;
 use App\Enums\ControlType;
@@ -23,6 +24,7 @@ use Filament\Infolists\Components\TextEntry;
 use Filament\Infolists\Infolist;
 use Filament\Resources\Resource;
 use Filament\Tables;
+use Filament\Tables\Columns\SelectColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Illuminate\Contracts\Support\Htmlable;
@@ -163,10 +165,11 @@ class ControlResource extends Resource
                     ->label('Applicability')
                     ->badge()
                     ->sortable(),
-                Tables\Columns\TextColumn::make('status')
-                    ->label(__('control.table.columns.status'))
-                    ->badge()
-                    ->sortable(),
+                SelectColumn::make('status')
+                    ->label('Status')
+                    ->options(ControlStatus::class)
+                    ->default(ControlStatus::NOT_STARTED),
+
                 Tables\Columns\TextColumn::make('created_at')
                     ->label(__('control.table.columns.created_at'))
                     ->dateTime()

--- a/app/Filament/Resources/ImplementationResource.php
+++ b/app/Filament/Resources/ImplementationResource.php
@@ -6,6 +6,7 @@ use App\Enums\Effectiveness;
 use App\Enums\ImplementationStatus;
 use App\Filament\Resources\ImplementationResource\Pages;
 use App\Filament\Resources\ImplementationResource\RelationManagers;
+use App\Filament\Resources\ImplementationResource\RelationManagers\TasksRelationManager;
 use App\Filament\Resources\RelationManagers\AssetAttachmentsRelationManager;
 use App\Models\Control;
 use App\Models\Implementation;
@@ -222,6 +223,7 @@ class ImplementationResource extends Resource
             RelationManagers\ControlsRelationManager::class,
             RelationManagers\AuditItemRelationManager::class,
             RelationManagers\RisksRelationManager::class,
+            RelationManagers\TasksRelationManager::class,
             AssetAttachmentsRelationManager::class,
         ];
     }

--- a/app/Filament/Resources/ImplementationResource/RelationManagers/TasksRelationManager.php
+++ b/app/Filament/Resources/ImplementationResource/RelationManagers/TasksRelationManager.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Filament\Resources\ImplementationResource\RelationManagers;
+
+use App\Enums\TaskRecurrence;
+use App\Enums\TaskStatus;
+use App\Models\Attachment;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
+
+class TasksRelationManager extends RelationManager
+{
+    protected static string $relationship = 'tasks';
+
+    public static ?string $title = 'Tasks';
+
+    public function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\TextInput::make('title')
+                    ->required()
+                    ->maxLength(255),
+                Forms\Components\DatePicker::make('task_date')
+                    ->label('Due Date')
+                    ->required(),
+                Forms\Components\Select::make('recurrence')
+                    ->options(TaskRecurrence::class)
+                    ->default(TaskRecurrence::NONE)
+                    ->native(false),
+                Forms\Components\Select::make('status')
+                    ->options(TaskStatus::class)
+                    ->default(TaskStatus::PENDING)
+                    ->native(false),
+                Forms\Components\Textarea::make('completion_notes')
+                    ->columnSpanFull(),
+                Forms\Components\Hidden::make('attachment_id'),
+                Forms\Components\FileUpload::make('attachment')
+                    ->label('Attachment')
+                    ->disk(config('filesystems.default'))
+                    ->directory('task-attachments')
+                    ->visibility('private')
+                    ->preserveFilenames()
+                    ->saveUploadedFileUsing(function (TemporaryUploadedFile $file, callable $set) {
+                        $path = $file->store('task-attachments', config('filesystems.default'));
+                        $attachment = Attachment::create([
+                            'file_name' => $file->getClientOriginalName(),
+                            'file_path' => $path,
+                            'file_size' => $file->getSize(),
+                            'uploaded_by' => auth()->id(),
+                        ]);
+                        $set('attachment_id', $attachment->id);
+                    })
+                    ->dehydrateStateUsing(fn () => null)
+                    ->downloadable()
+                    ->openable()
+                    ->columnSpanFull(),
+            ]);
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('title')->searchable(),
+                Tables\Columns\TextColumn::make('task_date')->label('Due')->date(),
+                Tables\Columns\TextColumn::make('status')->badge(),
+                Tables\Columns\TextColumn::make('recurrence'),
+            ])
+            ->headerActions([
+                Tables\Actions\CreateAction::make(),
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\DeleteAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+}

--- a/app/Filament/Resources/ImplementationResource/RelationManagers/TasksRelationManager.php
+++ b/app/Filament/Resources/ImplementationResource/RelationManagers/TasksRelationManager.php
@@ -25,7 +25,7 @@ class TasksRelationManager extends RelationManager
                 Forms\Components\TextInput::make('title')
                     ->required()
                     ->maxLength(255),
-                Forms\Components\DatePicker::make('task_date')
+                Forms\Components\DatePicker::make('due_at')
                     ->label('Due Date')
                     ->required(),
                 Forms\Components\Select::make('recurrence')
@@ -38,27 +38,27 @@ class TasksRelationManager extends RelationManager
                     ->native(false),
                 Forms\Components\Textarea::make('completion_notes')
                     ->columnSpanFull(),
-                Forms\Components\Hidden::make('attachment_id'),
-                Forms\Components\FileUpload::make('attachment')
-                    ->label('Attachment')
-                    ->disk(config('filesystems.default'))
-                    ->directory('task-attachments')
-                    ->visibility('private')
-                    ->preserveFilenames()
-                    ->saveUploadedFileUsing(function (TemporaryUploadedFile $file, callable $set) {
-                        $path = $file->store('task-attachments', config('filesystems.default'));
-                        $attachment = Attachment::create([
-                            'file_name' => $file->getClientOriginalName(),
-                            'file_path' => $path,
-                            'file_size' => $file->getSize(),
-                            'uploaded_by' => auth()->id(),
-                        ]);
-                        $set('attachment_id', $attachment->id);
-                    })
-                    ->dehydrateStateUsing(fn () => null)
-                    ->downloadable()
-                    ->openable()
-                    ->columnSpanFull(),
+                // Forms\Components\Hidden::make('attachment_id'),
+                // Forms\Components\FileUpload::make('attachment')
+                //     ->label('Attachment')
+                //     ->disk(config('filesystems.default'))
+                //     ->directory('task-attachments')
+                //     ->visibility('private')
+                //     ->preserveFilenames()
+                //     ->saveUploadedFileUsing(function (TemporaryUploadedFile $file, callable $set) {
+                //         $path = $file->store('task-attachments', config('filesystems.default'));
+                //         $attachment = Attachment::create([
+                //             'file_name' => $file->getClientOriginalName(),
+                //             'file_path' => $path,
+                //             'file_size' => $file->getSize(),
+                //             'uploaded_by' => auth()->id(),
+                //         ]);
+                //         $set('attachment_id', $attachment->id);
+                //     })
+                //     ->dehydrateStateUsing(fn () => null)
+                //     ->downloadable()
+                //     ->openable()
+                //     ->columnSpanFull(),
             ]);
     }
 
@@ -67,7 +67,7 @@ class TasksRelationManager extends RelationManager
         return $table
             ->columns([
                 Tables\Columns\TextColumn::make('title')->searchable(),
-                Tables\Columns\TextColumn::make('task_date')->label('Due')->date(),
+                Tables\Columns\TextColumn::make('due_at')->label('Due')->date(),
                 Tables\Columns\TextColumn::make('status')->badge(),
                 Tables\Columns\TextColumn::make('recurrence'),
             ])

--- a/app/Filament/Widgets/ImplementationTaskListWidget.php
+++ b/app/Filament/Widgets/ImplementationTaskListWidget.php
@@ -29,7 +29,7 @@ class ImplementationTaskListWidget extends BaseWidget
                     ->limit(100),
                 Tables\Columns\TextColumn::make('status')
                     ->badge(),
-                Tables\Columns\TextColumn::make('task_date')
+                Tables\Columns\TextColumn::make('due_at')
                     ->label('Due Date'),
             ])
             ->paginated(false);

--- a/app/Filament/Widgets/ImplementationTaskListWidget.php
+++ b/app/Filament/Widgets/ImplementationTaskListWidget.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Enums\TaskStatus;
+use App\Models\ImplementationTask;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Filament\Widgets\TableWidget as BaseWidget;
+use Illuminate\Support\HtmlString;
+
+class ImplementationTaskListWidget extends BaseWidget
+{
+    protected int|string|array $columnSpan = '2';
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(
+                ImplementationTask::query()->where('status', TaskStatus::PENDING)
+            )
+            ->heading('Implementation Tasks')
+            ->emptyStateHeading(new HtmlString('No tasks'))
+            ->columns([
+                Tables\Columns\TextColumn::make('implementation.title')
+                    ->label('Implementation'),
+                Tables\Columns\TextColumn::make('title')
+                    ->label('Task')
+                    ->limit(100),
+                Tables\Columns\TextColumn::make('status')
+                    ->badge(),
+                Tables\Columns\TextColumn::make('task_date')
+                    ->label('Due Date'),
+            ])
+            ->paginated(false);
+    }
+}

--- a/app/Livewire/DataRequestResponseTable.php
+++ b/app/Livewire/DataRequestResponseTable.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Livewire;
+
+use Livewire\Component;
+use Filament\Tables;
+use Filament\Tables\Concerns\InteractsWithTable;
+use Filament\Tables\Contracts\HasTable;
+use Illuminate\Database\Eloquent\Builder;
+use App\Models\DataRequestResponse;
+use Filament\Forms\Concerns\InteractsWithForms;
+use App\Enums\ResponseStatus;
+use Filament\Forms\Contracts\HasForms;
+
+class DataRequestResponseTable extends Component implements HasTable, HasForms
+{
+    use InteractsWithTable;
+    use InteractsWithForms;
+
+    protected function getTableQuery(): Builder
+    {
+        return DataRequestResponse::query()
+            ->where('requestee_id', auth()->id());
+    }
+
+    protected function getTableColumns(): array
+    {
+        return [
+            Tables\Columns\TextColumn::make('id')->label('ID')->sortable(),
+            Tables\Columns\TextColumn::make('dataRequest.audit.title')->label('Audit'),
+            Tables\Columns\TextColumn::make('dataRequest.details')->label('Requested Information')->html()->limit(100),
+            Tables\Columns\TextColumn::make('due_at')->label('Due At')->dateTime(),
+            Tables\Columns\TextColumn::make('status')->label('Status'),
+        ];
+    }
+
+
+    protected function getTableActions(): array
+    {
+        return [
+            Tables\Actions\Action::make('view')
+                ->label('Respond')
+                ->url(
+                    fn(DataRequestResponse $record) =>
+                    route('filament.app.resources.data-request-responses.edit', $record),
+                ),
+        ];
+    }
+
+
+
+    public function render()
+    {
+        return view('livewire.data-request-response-table');
+    }
+}

--- a/app/Livewire/PendingTasksTable.php
+++ b/app/Livewire/PendingTasksTable.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Livewire;
+
+use Livewire\Component;
+use Filament\Tables;
+use Filament\Tables\Concerns\InteractsWithTable;
+use Filament\Tables\Contracts\HasTable;
+use Illuminate\Database\Eloquent\Builder;
+use App\Models\ImplementationTask;
+use App\Enums\TaskStatus;
+use Filament\Forms\Concerns\InteractsWithForms;
+use Filament\Forms\Contracts\HasForms;
+use Filament\Tables\Columns\TextColumn;
+
+class PendingTasksTable extends Component implements HasTable, HasForms
+{
+    use InteractsWithTable;
+    use InteractsWithForms;
+
+    protected function getTableQuery(): Builder
+    {
+        return ImplementationTask::query()
+            ->where('status', TaskStatus::PENDING);
+    }
+
+    protected function getTableColumns(): array
+    {
+        return [
+            Tables\Columns\TextColumn::make('title')->label('Task'),
+            Tables\Columns\TextColumn::make('due_at')->label('Due At')->dateTime(),
+            TextColumn::make('recurrence')->label('Recurrence')->badge(),
+            Tables\Columns\TextColumn::make('status')->label('Status')->badge(),
+
+        ];
+    }
+
+    protected function getTableActions(): array
+    {
+        return [
+            Tables\Actions\Action::make('view')
+                ->label('View task')
+                ->url(
+                    fn(ImplementationTask $record) =>
+                    route('filament.app.resources.implementations.view', [$record->implementation,  'activeRelationManager' => 3]),
+                ),
+        ];
+    }
+
+    public function render()
+    {
+        return view('livewire.pending-tasks-table');
+    }
+}

--- a/app/Models/Implementation.php
+++ b/app/Models/Implementation.php
@@ -11,6 +11,8 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use App\Models\Attachment;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use App\Models\ImplementationTask;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Carbon;
@@ -147,5 +149,13 @@ class Implementation extends Model
     public function attachments(): MorphMany
     {
         return $this->morphMany(Attachment::class, 'attachable');
+    }
+
+    /**
+     * Get the tasks for the implementation.
+     */
+    public function tasks(): HasMany
+    {
+        return $this->hasMany(ImplementationTask::class);
     }
 }

--- a/app/Models/ImplementationTask.php
+++ b/app/Models/ImplementationTask.php
@@ -18,15 +18,17 @@ class ImplementationTask extends Model
         'title',
         'status',
         'completion_notes',
-        'task_date',
+        'due_at',
         'attachment_id',
         'recurrence',
     ];
 
+    protected $with = ['implementation'];
+
     protected $casts = [
         'status' => TaskStatus::class,
         'recurrence' => TaskRecurrence::class,
-        'task_date' => 'date',
+        'due_at' => 'date',
     ];
 
     public function implementation(): BelongsTo
@@ -44,7 +46,7 @@ class ImplementationTask extends Model
         static::updated(function (ImplementationTask $task) {
             if ($task->isDirty('status') && $task->status === TaskStatus::COMPLETED) {
                 if ($task->recurrence !== TaskRecurrence::NONE) {
-                    $date = $task->task_date ?? now();
+                    $date = $task->due_at ?? now();
                     $nextDate = match ($task->recurrence) {
                         TaskRecurrence::MONTHLY => Carbon::parse($date)->addMonth(),
                         TaskRecurrence::QUARTERLY => Carbon::parse($date)->addMonths(3),
@@ -60,7 +62,7 @@ class ImplementationTask extends Model
                             'status' => TaskStatus::PENDING,
                             'completion_notes' => null,
                             'attachment_id' => null,
-                            'task_date' => $nextDate,
+                            'due_at' => $nextDate,
                         ])->save();
                     }
                 }

--- a/app/Models/ImplementationTask.php
+++ b/app/Models/ImplementationTask.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\TaskRecurrence;
+use App\Enums\TaskStatus;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+class ImplementationTask extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'implementation_id',
+        'title',
+        'status',
+        'completion_notes',
+        'task_date',
+        'attachment_id',
+        'recurrence',
+    ];
+
+    protected $casts = [
+        'status' => TaskStatus::class,
+        'recurrence' => TaskRecurrence::class,
+        'task_date' => 'date',
+    ];
+
+    public function implementation(): BelongsTo
+    {
+        return $this->belongsTo(Implementation::class);
+    }
+
+    public function attachment(): BelongsTo
+    {
+        return $this->belongsTo(Attachment::class);
+    }
+
+    protected static function booted(): void
+    {
+        static::updated(function (ImplementationTask $task) {
+            if ($task->isDirty('status') && $task->status === TaskStatus::COMPLETED) {
+                if ($task->recurrence !== TaskRecurrence::NONE) {
+                    $date = $task->task_date ?? now();
+                    $nextDate = match ($task->recurrence) {
+                        TaskRecurrence::MONTHLY => Carbon::parse($date)->addMonth(),
+                        TaskRecurrence::QUARTERLY => Carbon::parse($date)->addMonths(3),
+                        TaskRecurrence::YEARLY => Carbon::parse($date)->addYear(),
+                        default => null,
+                    };
+                    if ($nextDate) {
+                        $task->replicate([
+                            'status',
+                            'completion_notes',
+                            'attachment_id',
+                        ])->fill([
+                            'status' => TaskStatus::PENDING,
+                            'completion_notes' => null,
+                            'attachment_id' => null,
+                            'task_date' => $nextDate,
+                        ])->save();
+                    }
+                }
+            }
+        });
+    }
+}

--- a/database/migrations/2025_06_10_000000_create_implementation_tasks_table.php
+++ b/database/migrations/2025_06_10_000000_create_implementation_tasks_table.php
@@ -14,7 +14,7 @@ return new class extends Migration
             $table->string('title');
             $table->string('status')->default('Pending');
             $table->text('completion_notes')->nullable();
-            $table->date('task_date')->nullable();
+            $table->date('due_at')->nullable();
             $table->foreignId('attachment_id')->nullable()->constrained('attachments')->nullOnDelete();
             $table->string('recurrence')->default('None');
             $table->timestamps();

--- a/database/migrations/2025_06_10_000000_create_implementation_tasks_table.php
+++ b/database/migrations/2025_06_10_000000_create_implementation_tasks_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('implementation_tasks', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('implementation_id')->constrained()->cascadeOnDelete();
+            $table->string('title');
+            $table->string('status')->default('Pending');
+            $table->text('completion_notes')->nullable();
+            $table->date('task_date')->nullable();
+            $table->foreignId('attachment_id')->nullable()->constrained('attachments')->nullOnDelete();
+            $table->string('recurrence')->default('None');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('implementation_tasks');
+    }
+};

--- a/resources/views/filament/pages/to-do.blade.php
+++ b/resources/views/filament/pages/to-do.blade.php
@@ -1,3 +1,4 @@
 <x-filament-panels::page>
     {{ $this->table }}
+    <livewire:filament.widgets.implementation-task-list-widget />
 </x-filament-panels::page>

--- a/resources/views/filament/pages/to-do.blade.php
+++ b/resources/views/filament/pages/to-do.blade.php
@@ -1,4 +1,14 @@
-<x-filament-panels::page>
-    {{ $this->table }}
-    <livewire:filament.widgets.implementation-task-list-widget />
-</x-filament-panels::page>
+<x-filament::page>
+    <x-filament::card>
+        <x-slot name="header">
+            <h2 class="text-xl font-bold">Your Data Requests</h2>
+        </x-slot>
+        @livewire('data-request-response-table')
+    </x-filament::card>
+    <x-filament::card>
+        <x-slot name="header">
+            <h2 class="text-xl font-bold">Your Pending Tasks</h2>
+        </x-slot>
+        @livewire('pending-tasks-table')
+    </x-filament::card>
+</x-filament::page>

--- a/resources/views/livewire/data-request-response-table.blade.php
+++ b/resources/views/livewire/data-request-response-table.blade.php
@@ -1,0 +1,3 @@
+<div>
+  {{ $this->table }}
+</div>

--- a/resources/views/livewire/pending-tasks-table.blade.php
+++ b/resources/views/livewire/pending-tasks-table.blade.php
@@ -1,0 +1,3 @@
+<div>
+    {{ $this->table }}
+</div>


### PR DESCRIPTION
## Summary
- add `TaskStatus` and `TaskRecurrence` enums
- create `ImplementationTask` model and migration
- relate `Implementation` model to its tasks
- provide relation manager for tasks in `ImplementationResource`
- show tasks on the ToDo page using a new widget
- update navigation badge count to include implementation tasks

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684699394b588325828ad5a2fc90f05c