### PR TITLE
Add global processing activity resources

### DIFF
--- a/app/Filament/Resources/BusinessDataEntryResource.php
+++ b/app/Filament/Resources/BusinessDataEntryResource.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources;
 use App\Enums\BusinessCriticalDataType;
 use App\Models\BusinessDataEntry;
 use App\Filament\Resources\BusinessDataEntryResource\Pages;
+use App\Filament\Resources\RelationManagers\BusinessDataEntriesRelationManager;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
@@ -56,6 +57,11 @@ class BusinessDataEntryResource extends Resource
     {
         return $table
             ->columns([
+                Tables\Columns\TextColumn::make('processable.name')
+                    ->label('System')
+                    ->wrap()
+                    ->sortable()
+                    ->hiddenOn(BusinessDataEntriesRelationManager::class),
                 Tables\Columns\TextColumn::make('process_name')
                     ->label('Process')
                     ->sortable(),
@@ -68,9 +74,7 @@ class BusinessDataEntryResource extends Resource
                     ->wrap(),
             ])
             ->defaultSort('id', 'asc')
-            ->headerActions([
-                Tables\Actions\CreateAction::make(),
-            ])
+            ->headerActions([])
             ->actions([
                 Tables\Actions\EditAction::make(),
                 Tables\Actions\DeleteAction::make(),

--- a/app/Filament/Resources/BusinessDataEntryResource.php
+++ b/app/Filament/Resources/BusinessDataEntryResource.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Enums\BusinessCriticalDataType;
+use App\Models\BusinessDataEntry;
+use App\Filament\Resources\BusinessDataEntryResource\Pages;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+
+class BusinessDataEntryResource extends Resource
+{
+    protected static ?string $model = BusinessDataEntry::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+
+    protected static ?string $navigationGroup = 'Foundations';
+
+    public static function getNavigationLabel(): string
+    {
+        return __('business-data-entry.navigation.label');
+    }
+
+    public static function getNavigationGroup(): string
+    {
+        return __('business-data-entry.navigation.group');
+    }
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\TextInput::make('process_name')
+                    ->label('Process Name')
+                    ->columnSpanFull(),
+                Forms\Components\Textarea::make('purpose')
+                    ->label('Purpose')
+                    ->rows(3)
+                    ->columnSpanFull(),
+                Forms\Components\CheckboxList::make('data_types')
+                    ->options(array_combine(
+                        array_column(BusinessCriticalDataType::cases(), 'value'),
+                        array_map(fn($case) => $case->getLabel(), BusinessCriticalDataType::cases())
+                    ))
+                    ->columns(2)
+                    ->columnSpanFull()
+                    ->required(),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('process_name')
+                    ->label('Process')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('purpose')
+                    ->label('Purpose')
+                    ->wrap(),
+                Tables\Columns\TextColumn::make('data_types')
+                    ->label('Data Types')
+                    ->formatStateUsing(fn($state) => is_array($state) ? implode(', ', $state) : $state)
+                    ->wrap(),
+            ])
+            ->defaultSort('id', 'asc')
+            ->headerActions([
+                Tables\Actions\CreateAction::make(),
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\DeleteAction::make(),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListBusinessDataEntries::route('/'),
+            'create' => Pages\CreateBusinessDataEntry::route('/create'),
+            'view' => Pages\ViewBusinessDataEntry::route('/{record}'),
+            'edit' => Pages\EditBusinessDataEntry::route('/{record}/edit'),
+        ];
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery();
+    }
+}

--- a/app/Filament/Resources/BusinessDataEntryResource/Pages/CreateBusinessDataEntry.php
+++ b/app/Filament/Resources/BusinessDataEntryResource/Pages/CreateBusinessDataEntry.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace App\\Filament\\Resources\\BusinessDataEntryResource\\Pages;
+namespace App\Filament\Resources\BusinessDataEntryResource\Pages;
 
-use App\\Filament\\Resources\\BusinessDataEntryResource;
-use Filament\\Resources\\Pages\\CreateRecord;
+use App\Filament\Resources\BusinessDataEntryResource;
+use Filament\Resources\Pages\CreateRecord;
 
 class CreateBusinessDataEntry extends CreateRecord
 {

--- a/app/Filament/Resources/BusinessDataEntryResource/Pages/CreateBusinessDataEntry.php
+++ b/app/Filament/Resources/BusinessDataEntryResource/Pages/CreateBusinessDataEntry.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\\Filament\\Resources\\BusinessDataEntryResource\\Pages;
+
+use App\\Filament\\Resources\\BusinessDataEntryResource;
+use Filament\\Resources\\Pages\\CreateRecord;
+
+class CreateBusinessDataEntry extends CreateRecord
+{
+    protected static string $resource = BusinessDataEntryResource::class;
+}

--- a/app/Filament/Resources/BusinessDataEntryResource/Pages/EditBusinessDataEntry.php
+++ b/app/Filament/Resources/BusinessDataEntryResource/Pages/EditBusinessDataEntry.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\\Filament\\Resources\\BusinessDataEntryResource\\Pages;
+
+use App\\Filament\\Resources\\BusinessDataEntryResource;
+use Filament\\Resources\\Pages\\EditRecord;
+
+class EditBusinessDataEntry extends EditRecord
+{
+    protected static string $resource = BusinessDataEntryResource::class;
+}

--- a/app/Filament/Resources/BusinessDataEntryResource/Pages/EditBusinessDataEntry.php
+++ b/app/Filament/Resources/BusinessDataEntryResource/Pages/EditBusinessDataEntry.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace App\\Filament\\Resources\\BusinessDataEntryResource\\Pages;
+namespace App\Filament\Resources\BusinessDataEntryResource\Pages;
 
-use App\\Filament\\Resources\\BusinessDataEntryResource;
-use Filament\\Resources\\Pages\\EditRecord;
+use App\Filament\Resources\BusinessDataEntryResource;
+use Filament\Resources\Pages\EditRecord;
 
 class EditBusinessDataEntry extends EditRecord
 {

--- a/app/Filament/Resources/BusinessDataEntryResource/Pages/ListBusinessDataEntries.php
+++ b/app/Filament/Resources/BusinessDataEntryResource/Pages/ListBusinessDataEntries.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Filament\Resources\BusinessDataEntryResource\Pages;
+
+use App\Filament\Resources\BusinessDataEntryResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListBusinessDataEntries extends ListRecords
+{
+    protected static string $resource = BusinessDataEntryResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+            Actions\Action::make('export')
+                ->label('Export')
+                ->icon('heroicon-o-arrow-down-tray')
+                ->action(fn() => $this->export()),
+        ];
+    }
+
+    protected function export()
+    {
+        $records = BusinessDataEntryResource::getModel()::with('processable')->get();
+
+        return response()->streamDownload(function () use ($records) {
+            $file = fopen('php://output', 'w');
+            fputcsv($file, ['ID', 'Process Name', 'Purpose', 'Data Types', 'Processable Type', 'Processable ID']);
+            foreach ($records as $record) {
+                fputcsv($file, [
+                    $record->id,
+                    $record->process_name,
+                    $record->purpose,
+                    implode(',', (array) $record->data_types),
+                    class_basename($record->processable_type ?? ''),
+                    $record->processable_id,
+                ]);
+            }
+            fclose($file);
+        }, 'business-data-entries.csv');
+    }
+}

--- a/app/Filament/Resources/BusinessDataEntryResource/Pages/ViewBusinessDataEntry.php
+++ b/app/Filament/Resources/BusinessDataEntryResource/Pages/ViewBusinessDataEntry.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace App\\Filament\\Resources\\BusinessDataEntryResource\\Pages;
+namespace App\Filament\Resources\BusinessDataEntryResource\Pages;
 
-use App\\Filament\\Resources\\BusinessDataEntryResource;
-use Filament\\Resources\\Pages\\ViewRecord;
+use App\Filament\Resources\BusinessDataEntryResource;
+use Filament\Resources\Pages\ViewRecord;
 
 class ViewBusinessDataEntry extends ViewRecord
 {

--- a/app/Filament/Resources/BusinessDataEntryResource/Pages/ViewBusinessDataEntry.php
+++ b/app/Filament/Resources/BusinessDataEntryResource/Pages/ViewBusinessDataEntry.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\\Filament\\Resources\\BusinessDataEntryResource\\Pages;
+
+use App\\Filament\\Resources\\BusinessDataEntryResource;
+use Filament\\Resources\\Pages\\ViewRecord;
+
+class ViewBusinessDataEntry extends ViewRecord
+{
+    protected static string $resource = BusinessDataEntryResource::class;
+}

--- a/app/Filament/Resources/PersonalDataEntryResource.php
+++ b/app/Filament/Resources/PersonalDataEntryResource.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Enums\DataSubjectCategory;
+use App\Enums\PersonalDataType;
+use App\Models\PersonalDataEntry;
+use App\Filament\Resources\PersonalDataEntryResource\Pages;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+
+class PersonalDataEntryResource extends Resource
+{
+    protected static ?string $model = PersonalDataEntry::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-user';
+
+    protected static ?string $navigationGroup = 'Foundations';
+
+    public static function getNavigationLabel(): string
+    {
+        return __('personal-data-entry.navigation.label');
+    }
+
+    public static function getNavigationGroup(): string
+    {
+        return __('personal-data-entry.navigation.group');
+    }
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\TextInput::make('process_name')
+                    ->label('Process Name')
+                    ->columnSpanFull(),
+                Forms\Components\Textarea::make('purpose')
+                    ->label('Purpose')
+                    ->columnSpanFull()
+                    ->rows(3),
+                Forms\Components\Select::make('subject_category')
+                    ->required()
+                    ->columnSpanFull()
+                    ->options(array_combine(
+                        array_column(DataSubjectCategory::cases(), 'value'),
+                        array_map(fn($case) => $case->getLabel(), DataSubjectCategory::cases())
+                    )),
+                Forms\Components\CheckboxList::make('data_types')
+                    ->columnSpanFull()
+                    ->options(array_combine(
+                        array_column(PersonalDataType::cases(), 'value'),
+                        array_map(fn($case) => $case->getLabel(), PersonalDataType::cases())
+                    ))
+                    ->columns(2)
+                    ->required(),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('subject_category')
+                    ->label('Category')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('data_types')
+                    ->label('Data Types')
+                    ->formatStateUsing(fn($state) => is_array($state) ? implode(', ', $state) : $state)
+                    ->wrap(),
+            ])
+            ->defaultSort('id', 'asc')
+            ->headerActions([
+                Tables\Actions\CreateAction::make(),
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\DeleteAction::make(),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListPersonalDataEntries::route('/'),
+            'create' => Pages\CreatePersonalDataEntry::route('/create'),
+            'view' => Pages\ViewPersonalDataEntry::route('/{record}'),
+            'edit' => Pages\EditPersonalDataEntry::route('/{record}/edit'),
+        ];
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery();
+    }
+}

--- a/app/Filament/Resources/PersonalDataEntryResource.php
+++ b/app/Filament/Resources/PersonalDataEntryResource.php
@@ -6,6 +6,7 @@ use App\Enums\DataSubjectCategory;
 use App\Enums\PersonalDataType;
 use App\Models\PersonalDataEntry;
 use App\Filament\Resources\PersonalDataEntryResource\Pages;
+use App\Filament\Resources\RelationManagers\PersonalDataEntriesRelationManager;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
@@ -64,6 +65,11 @@ class PersonalDataEntryResource extends Resource
     {
         return $table
             ->columns([
+                Tables\Columns\TextColumn::make('processable.name')
+                    ->label('System')
+                    ->wrap()
+                    ->sortable()
+                    ->hiddenOn(PersonalDataEntriesRelationManager::class),
                 Tables\Columns\TextColumn::make('subject_category')
                     ->label('Category')
                     ->sortable(),
@@ -73,9 +79,6 @@ class PersonalDataEntryResource extends Resource
                     ->wrap(),
             ])
             ->defaultSort('id', 'asc')
-            ->headerActions([
-                Tables\Actions\CreateAction::make(),
-            ])
             ->actions([
                 Tables\Actions\EditAction::make(),
                 Tables\Actions\DeleteAction::make(),

--- a/app/Filament/Resources/PersonalDataEntryResource/Pages/CreatePersonalDataEntry.php
+++ b/app/Filament/Resources/PersonalDataEntryResource/Pages/CreatePersonalDataEntry.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\\Filament\\Resources\\PersonalDataEntryResource\\Pages;
+
+use App\\Filament\\Resources\\PersonalDataEntryResource;
+use Filament\\Resources\\Pages\\CreateRecord;
+
+class CreatePersonalDataEntry extends CreateRecord
+{
+    protected static string $resource = PersonalDataEntryResource::class;
+}

--- a/app/Filament/Resources/PersonalDataEntryResource/Pages/CreatePersonalDataEntry.php
+++ b/app/Filament/Resources/PersonalDataEntryResource/Pages/CreatePersonalDataEntry.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace App\\Filament\\Resources\\PersonalDataEntryResource\\Pages;
+namespace App\Filament\Resources\PersonalDataEntryResource\Pages;
 
-use App\\Filament\\Resources\\PersonalDataEntryResource;
-use Filament\\Resources\\Pages\\CreateRecord;
+use App\Filament\Resources\PersonalDataEntryResource;
+use Filament\Resources\Pages\CreateRecord;
 
 class CreatePersonalDataEntry extends CreateRecord
 {

--- a/app/Filament/Resources/PersonalDataEntryResource/Pages/EditPersonalDataEntry.php
+++ b/app/Filament/Resources/PersonalDataEntryResource/Pages/EditPersonalDataEntry.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace App\\Filament\\Resources\\PersonalDataEntryResource\\Pages;
+namespace App\Filament\Resources\PersonalDataEntryResource\Pages;
 
-use App\\Filament\\Resources\\PersonalDataEntryResource;
-use Filament\\Resources\\Pages\\EditRecord;
+use App\Filament\Resources\PersonalDataEntryResource;
+use Filament\Resources\Pages\EditRecord;
 
 class EditPersonalDataEntry extends EditRecord
 {

--- a/app/Filament/Resources/PersonalDataEntryResource/Pages/EditPersonalDataEntry.php
+++ b/app/Filament/Resources/PersonalDataEntryResource/Pages/EditPersonalDataEntry.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\\Filament\\Resources\\PersonalDataEntryResource\\Pages;
+
+use App\\Filament\\Resources\\PersonalDataEntryResource;
+use Filament\\Resources\\Pages\\EditRecord;
+
+class EditPersonalDataEntry extends EditRecord
+{
+    protected static string $resource = PersonalDataEntryResource::class;
+}

--- a/app/Filament/Resources/PersonalDataEntryResource/Pages/ListPersonalDataEntries.php
+++ b/app/Filament/Resources/PersonalDataEntryResource/Pages/ListPersonalDataEntries.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Filament\Resources\PersonalDataEntryResource\Pages;
+
+use App\Filament\Resources\PersonalDataEntryResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListPersonalDataEntries extends ListRecords
+{
+    protected static string $resource = PersonalDataEntryResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+            Actions\Action::make('export')
+                ->label('Export')
+                ->icon('heroicon-o-arrow-down-tray')
+                ->action(fn() => $this->export()),
+        ];
+    }
+
+    protected function export()
+    {
+        $records = PersonalDataEntryResource::getModel()::with('processable')->get();
+
+        return response()->streamDownload(function () use ($records) {
+            $file = fopen('php://output', 'w');
+            fputcsv($file, ['ID','Category','Process Name','Purpose','Data Types','Processable Type','Processable ID']);
+            foreach ($records as $record) {
+                fputcsv($file, [
+                    $record->id,
+                    $record->subject_category,
+                    $record->process_name,
+                    $record->purpose,
+                    implode(',', (array) $record->data_types),
+                    class_basename($record->processable_type ?? ''),
+                    $record->processable_id,
+                ]);
+            }
+            fclose($file);
+        }, 'personal-data-entries.csv');
+    }
+}

--- a/app/Filament/Resources/PersonalDataEntryResource/Pages/ViewPersonalDataEntry.php
+++ b/app/Filament/Resources/PersonalDataEntryResource/Pages/ViewPersonalDataEntry.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace App\\Filament\\Resources\\PersonalDataEntryResource\\Pages;
+namespace App\Filament\Resources\PersonalDataEntryResource\Pages;
 
-use App\\Filament\\Resources\\PersonalDataEntryResource;
-use Filament\\Resources\\Pages\\ViewRecord;
+use App\Filament\Resources\PersonalDataEntryResource;
+use Filament\Resources\Pages\ViewRecord;
 
 class ViewPersonalDataEntry extends ViewRecord
 {

--- a/app/Filament/Resources/PersonalDataEntryResource/Pages/ViewPersonalDataEntry.php
+++ b/app/Filament/Resources/PersonalDataEntryResource/Pages/ViewPersonalDataEntry.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\\Filament\\Resources\\PersonalDataEntryResource\\Pages;
+
+use App\\Filament\\Resources\\PersonalDataEntryResource;
+use Filament\\Resources\\Pages\\ViewRecord;
+
+class ViewPersonalDataEntry extends ViewRecord
+{
+    protected static string $resource = PersonalDataEntryResource::class;
+}

--- a/app/Filament/Resources/RelationManagers/BusinessDataEntriesRelationManager.php
+++ b/app/Filament/Resources/RelationManagers/BusinessDataEntriesRelationManager.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\RelationManagers;
 use App\Filament\Resources\BusinessDataEntryResource;
 use Filament\Forms\Form;
 use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables\Actions\CreateAction;
 use Filament\Tables\Table;
 
 class BusinessDataEntriesRelationManager extends RelationManager
@@ -18,6 +19,9 @@ class BusinessDataEntriesRelationManager extends RelationManager
 
     public function table(Table $table): Table
     {
-        return BusinessDataEntryResource::table($table);
+        return BusinessDataEntryResource::table($table)
+            ->headerActions([
+                CreateAction::make(),
+            ]);
     }
 }

--- a/app/Filament/Resources/RelationManagers/BusinessDataEntriesRelationManager.php
+++ b/app/Filament/Resources/RelationManagers/BusinessDataEntriesRelationManager.php
@@ -2,11 +2,9 @@
 
 namespace App\Filament\Resources\RelationManagers;
 
-use App\Enums\BusinessCriticalDataType;
-use Filament\Forms;
+use App\Filament\Resources\BusinessDataEntryResource;
 use Filament\Forms\Form;
 use Filament\Resources\RelationManagers\RelationManager;
-use Filament\Tables;
 use Filament\Tables\Table;
 
 class BusinessDataEntriesRelationManager extends RelationManager
@@ -15,52 +13,11 @@ class BusinessDataEntriesRelationManager extends RelationManager
 
     public function form(Form $form): Form
     {
-        return $form
-            ->schema([
-                Forms\Components\TextInput::make('process_name')
-                    ->label('Process Name')
-                    ->columnSpanFull(),
-                Forms\Components\Textarea::make('purpose')
-                    ->label('Purpose')
-                    ->rows(3)
-                    ->columnSpanFull(),
-                Forms\Components\CheckboxList::make('data_types')
-                    ->options(array_combine(
-                        array_column(BusinessCriticalDataType::cases(), 'value'),
-                        array_map(fn($case) => $case->getLabel(), BusinessCriticalDataType::cases())
-                    ))
-                    ->columns(2)
-                    ->columnSpanFull()
-                    ->required(),
-            ]);
+        return BusinessDataEntryResource::form($form);
     }
 
     public function table(Table $table): Table
     {
-        return $table
-            ->columns([
-                Tables\Columns\TextColumn::make('process_name')
-                    ->label('Process')
-                    ->sortable(),
-                Tables\Columns\TextColumn::make('purpose')
-                    ->label('Purpose')
-                    ->wrap(),
-                Tables\Columns\TextColumn::make('data_types')
-                    ->label('Data Types')
-                    ->formatStateUsing(fn($state) => is_array($state) ? implode(', ', $state) : $state)
-                    ->wrap(),
-            ])
-            ->headerActions([
-                Tables\Actions\CreateAction::make(),
-            ])
-            ->actions([
-                Tables\Actions\EditAction::make(),
-                Tables\Actions\DeleteAction::make(),
-            ])
-            ->bulkActions([
-                Tables\Actions\BulkActionGroup::make([
-                    Tables\Actions\DeleteBulkAction::make(),
-                ]),
-            ]);
+        return BusinessDataEntryResource::table($table);
     }
 }

--- a/app/Filament/Resources/RelationManagers/PersonalDataEntriesRelationManager.php
+++ b/app/Filament/Resources/RelationManagers/PersonalDataEntriesRelationManager.php
@@ -2,12 +2,9 @@
 
 namespace App\Filament\Resources\RelationManagers;
 
-use App\Enums\DataSubjectCategory;
-use App\Enums\PersonalDataType;
-use Filament\Forms;
+use App\Filament\Resources\PersonalDataEntryResource;
 use Filament\Forms\Form;
 use Filament\Resources\RelationManagers\RelationManager;
-use Filament\Tables;
 use Filament\Tables\Table;
 
 class PersonalDataEntriesRelationManager extends RelationManager
@@ -16,57 +13,11 @@ class PersonalDataEntriesRelationManager extends RelationManager
 
     public function form(Form $form): Form
     {
-        return $form
-            ->schema([
-                Forms\Components\TextInput::make('process_name')
-                    ->label('Process Name')
-                    ->columnSpanFull(),
-                Forms\Components\Textarea::make('purpose')
-                    ->label('Purpose')
-                    ->columnSpanFull()
-                    ->rows(3),
-                Forms\Components\Select::make('subject_category')
-                    ->required()
-                    ->columnSpanFull()
-                    ->options(array_combine(
-                        array_column(DataSubjectCategory::cases(), 'value'),
-                        array_map(fn($case) => $case->getLabel(), DataSubjectCategory::cases())
-                    )),
-                Forms\Components\CheckboxList::make('data_types')
-                    ->columnSpanFull()
-                    ->options(array_combine(
-                        array_column(PersonalDataType::cases(), 'value'),
-                        array_map(fn($case) => $case->getLabel(), PersonalDataType::cases())
-                    ))
-                    ->columns(2)
-                    ->required(),
-
-            ]);
+        return PersonalDataEntryResource::form($form);
     }
 
     public function table(Table $table): Table
     {
-        return $table
-            ->columns([
-                Tables\Columns\TextColumn::make('subject_category')
-                    ->label('Category')
-                    ->sortable(),
-                Tables\Columns\TextColumn::make('data_types')
-                    ->label('Data Types')
-                    ->formatStateUsing(fn($state) => is_array($state) ? implode(', ', $state) : $state)
-                    ->wrap(),
-            ])
-            ->headerActions([
-                Tables\Actions\CreateAction::make(),
-            ])
-            ->actions([
-                Tables\Actions\EditAction::make(),
-                Tables\Actions\DeleteAction::make(),
-            ])
-            ->bulkActions([
-                Tables\Actions\BulkActionGroup::make([
-                    Tables\Actions\DeleteBulkAction::make(),
-                ]),
-            ]);
+        return PersonalDataEntryResource::table($table);
     }
 }

--- a/app/Filament/Resources/RelationManagers/PersonalDataEntriesRelationManager.php
+++ b/app/Filament/Resources/RelationManagers/PersonalDataEntriesRelationManager.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\RelationManagers;
 use App\Filament\Resources\PersonalDataEntryResource;
 use Filament\Forms\Form;
 use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables\Actions\CreateAction;
 use Filament\Tables\Table;
 
 class PersonalDataEntriesRelationManager extends RelationManager
@@ -18,6 +19,9 @@ class PersonalDataEntriesRelationManager extends RelationManager
 
     public function table(Table $table): Table
     {
-        return PersonalDataEntryResource::table($table);
+        return PersonalDataEntryResource::table($table)
+            ->headerActions([
+                CreateAction::make(),
+            ]);
     }
 }

--- a/lang/en/business-data-entry.php
+++ b/lang/en/business-data-entry.php
@@ -1,0 +1,11 @@
+<?php
+
+return [
+    'navigation' => [
+        'label' => 'Business Data',
+        'group' => 'Foundations',
+    ],
+    'breadcrumb' => [
+        'title' => 'Business Data Entries',
+    ],
+];

--- a/lang/en/personal-data-entry.php
+++ b/lang/en/personal-data-entry.php
@@ -1,0 +1,11 @@
+<?php
+
+return [
+    'navigation' => [
+        'label' => 'Personal Data',
+        'group' => 'Foundations',
+    ],
+    'breadcrumb' => [
+        'title' => 'Personal Data Entries',
+    ],
+];


### PR DESCRIPTION
## Summary
- add BusinessDataEntryResource and PersonalDataEntryResource
- create CRUD pages with CSV export for both resources
- expose shared forms and tables via RelationManagers
- add language strings for new resources

## Testing
- `php artisan test` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6846b4afed3483259ed03aaf03ded703