### PR TITLE
Rename systems title to name

### DIFF
--- a/app/Filament/Resources/BusinessDataEntryResource.php
+++ b/app/Filament/Resources/BusinessDataEntryResource.php
@@ -58,7 +58,7 @@ class BusinessDataEntryResource extends Resource
         return $table
             ->columns([
                 Tables\Columns\TextColumn::make('processable.name')
-                    ->label('System')
+                    ->label('Vendor / system')
                     ->wrap()
                     ->sortable()
                     ->hiddenOn(BusinessDataEntriesRelationManager::class),

--- a/app/Filament/Resources/BusinessDataEntryResource/Pages/ListBusinessDataEntries.php
+++ b/app/Filament/Resources/BusinessDataEntryResource/Pages/ListBusinessDataEntries.php
@@ -13,7 +13,6 @@ class ListBusinessDataEntries extends ListRecords
     protected function getHeaderActions(): array
     {
         return [
-            Actions\CreateAction::make(),
             Actions\Action::make('export')
                 ->label('Export')
                 ->icon('heroicon-o-arrow-down-tray')

--- a/app/Filament/Resources/PersonalDataEntryResource.php
+++ b/app/Filament/Resources/PersonalDataEntryResource.php
@@ -66,7 +66,7 @@ class PersonalDataEntryResource extends Resource
         return $table
             ->columns([
                 Tables\Columns\TextColumn::make('processable.name')
-                    ->label('System')
+                    ->label('Vendor / system')
                     ->wrap()
                     ->sortable()
                     ->hiddenOn(PersonalDataEntriesRelationManager::class),

--- a/app/Filament/Resources/PersonalDataEntryResource/Pages/ListPersonalDataEntries.php
+++ b/app/Filament/Resources/PersonalDataEntryResource/Pages/ListPersonalDataEntries.php
@@ -13,7 +13,6 @@ class ListPersonalDataEntries extends ListRecords
     protected function getHeaderActions(): array
     {
         return [
-            Actions\CreateAction::make(),
             Actions\Action::make('export')
                 ->label('Export')
                 ->icon('heroicon-o-arrow-down-tray')
@@ -27,7 +26,7 @@ class ListPersonalDataEntries extends ListRecords
 
         return response()->streamDownload(function () use ($records) {
             $file = fopen('php://output', 'w');
-            fputcsv($file, ['ID','Category','Process Name','Purpose','Data Types','Processable Type','Processable ID']);
+            fputcsv($file, ['ID', 'Category', 'Process Name', 'Purpose', 'Data Types', 'Processable Type', 'Processable ID']);
             foreach ($records as $record) {
                 fputcsv($file, [
                     $record->id,

--- a/app/Filament/Resources/SystemResource.php
+++ b/app/Filament/Resources/SystemResource.php
@@ -54,8 +54,8 @@ class SystemResource extends Resource
                 Forms\Components\Section::make('General Information')
                     ->columns(3)
                     ->schema([
-                        Forms\Components\TextInput::make('title')
-                            ->label(__('system.form.title'))
+                        Forms\Components\TextInput::make('name')
+                            ->label(__('system.form.name'))
                             ->required()
                             ->maxLength(255)
                             ->columnSpan(2),
@@ -101,8 +101,8 @@ class SystemResource extends Resource
     {
         return $table
             ->columns([
-                Tables\Columns\TextColumn::make('title')
-                    ->label(__('system.table.columns.title'))
+                Tables\Columns\TextColumn::make('name')
+                    ->label(__('system.table.columns.name'))
                     ->searchable()
                     ->sortable(),
                 Tables\Columns\TextColumn::make('vendor.name')
@@ -165,6 +165,6 @@ class SystemResource extends Resource
      */
     public static function getGlobalSearchResultTitle(Model $record): string|Htmlable
     {
-        return $record->title;
+        return $record->name;
     }
 }

--- a/app/Filament/Resources/SystemResource.php
+++ b/app/Filament/Resources/SystemResource.php
@@ -9,6 +9,7 @@ use App\Filament\Resources\SystemResource\Pages;
 use App\Models\System;
 use App\Models\Vendor;
 use App\Filament\Resources\SystemResource\RelationManagers;
+use App\Filament\Resources\VendorResource\RelationManagers\SystemsRelationManager;
 use Filament\Forms;
 use Filament\Forms\Components\Section;
 use Filament\Forms\Form;
@@ -106,6 +107,7 @@ class SystemResource extends Resource
                     ->searchable()
                     ->sortable(),
                 Tables\Columns\TextColumn::make('vendor.name')
+                    ->hiddenOn(SystemsRelationManager::class)
                     ->label(__('system.table.columns.vendor'))
                     ->sortable()
                     ->toggleable(),

--- a/app/Filament/Resources/VendorResource/RelationManagers/SystemsRelationManager.php
+++ b/app/Filament/Resources/VendorResource/RelationManagers/SystemsRelationManager.php
@@ -14,7 +14,7 @@ class SystemsRelationManager extends RelationManager
 {
     protected static string $relationship = 'systems';
 
-    protected static ?string $recordTitleAttribute = 'title';
+    protected static ?string $recordTitleAttribute = 'name';
 
     public function form(Form $form): Form
     {
@@ -24,8 +24,8 @@ class SystemsRelationManager extends RelationManager
                 Forms\Components\Section::make('General Information')
                     ->columns(3)
                     ->schema([
-                        Forms\Components\TextInput::make('title')
-                            ->label(__('system.form.title'))
+                        Forms\Components\TextInput::make('name')
+                            ->label(__('system.form.name'))
                             ->required()
                             ->maxLength(255)
                             ->columnSpan(2),
@@ -68,8 +68,8 @@ class SystemsRelationManager extends RelationManager
     {
         return $table
             ->columns([
-                Tables\Columns\TextColumn::make('title')
-                    ->label(__('system.table.columns.title'))
+                Tables\Columns\TextColumn::make('name')
+                    ->label(__('system.table.columns.name'))
                     ->searchable()
                     ->sortable(),
                 Tables\Columns\IconColumn::make('security_password_policy_compliant')

--- a/app/Filament/Resources/VendorResource/RelationManagers/SystemsRelationManager.php
+++ b/app/Filament/Resources/VendorResource/RelationManagers/SystemsRelationManager.php
@@ -3,8 +3,6 @@
 namespace App\Filament\Resources\VendorResource\RelationManagers;
 
 use App\Filament\Resources\SystemResource;
-use App\Models\Vendor;
-use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables;
@@ -18,73 +16,18 @@ class SystemsRelationManager extends RelationManager
 
     public function form(Form $form): Form
     {
-        return $form
-            ->columns(2)
-            ->schema([
-                Forms\Components\Section::make('General Information')
-                    ->columns(3)
-                    ->schema([
-                        Forms\Components\TextInput::make('name')
-                            ->label(__('system.form.name'))
-                            ->required()
-                            ->maxLength(255)
-                            ->columnSpan(2),
-                        Forms\Components\Select::make('vendor_id')
-                            ->label(__('system.form.vendor'))
-                            ->options(Vendor::pluck('name', 'id'))
-                            ->searchable()
-                            ->preload()
-                            ->nullable(),
-                        Forms\Components\Textarea::make('description')
-                            ->label(__('system.form.description'))
-                            ->columnSpanFull(),
-                        Forms\Components\TextInput::make('system_documentation_link')
-                            ->label(__('system.form.system_document_link'))
-                            ->maxLength(255)
-                            ->nullable(),
-                    ]),
-
-                Forms\Components\Section::make('Security and compliance')
-                    ->columns(3)
-                    ->schema([
-                        Forms\Components\CheckboxList::make('data_storage')
-                            ->label(__('system.form.data_storage'))
-                            ->options(array_combine(
-                                array_column(\App\Enums\DataStorageType::cases(), 'value'),
-                                array_map(fn($case) => $case->getLabel(), \App\Enums\DataStorageType::cases())
-                            ))
-                            ->columns(2)
-                            ->columnSpan(3)
-                            ->nullable(),
-                        Forms\Components\Toggle::make('security_password_policy_compliant')
-                            ->label(__('system.form.security_password_policy_compliant')),
-                        Forms\Components\Toggle::make('security_sso_connected')
-                            ->label(__('system.form.security_sso_connected')),
-                    ]),
-            ]);
+        return SystemResource::form($form);
     }
 
     public function table(Table $table): Table
     {
-        return $table
-            ->columns([
-                Tables\Columns\TextColumn::make('name')
-                    ->label(__('system.table.columns.name'))
-                    ->searchable()
-                    ->sortable(),
-                Tables\Columns\IconColumn::make('security_password_policy_compliant')
-                    ->label(__('system.table.columns.security_password_policy_compliant'))
-                    ->boolean(),
-                Tables\Columns\IconColumn::make('security_sso_connected')
-                    ->label(__('system.table.columns.security_sso_connected'))
-                    ->boolean(),
-            ])
+        return SystemResource::table($table)
             ->headerActions([
                 Tables\Actions\CreateAction::make(),
             ])
             ->actions([
                 Tables\Actions\ViewAction::make()->url(fn($record) => SystemResource::getUrl('view', ['record' => $record])),
-                Tables\Actions\DeleteAction::make()
+                Tables\Actions\DeleteAction::make(),
             ])
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([

--- a/database/migrations/2025_06_03_140000_rename_title_to_name_in_systems_table.php
+++ b/database/migrations/2025_06_03_140000_rename_title_to_name_in_systems_table.php
@@ -1,0 +1,39 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('systems', function (Blueprint $table) {
+            $table->string('name')->after('id')->nullable();
+        });
+
+        // Copy data from title to name
+        \DB::table('systems')->update([
+            'name' => \DB::raw('title')
+        ]);
+
+        Schema::table('systems', function (Blueprint $table) {
+            $table->dropColumn('title');
+            $table->string('name')->nullable(false)->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('systems', function (Blueprint $table) {
+            $table->string('title')->after('id');
+        });
+
+        \DB::table('systems')->update([
+            'title' => \DB::raw('name')
+        ]);
+
+        Schema::table('systems', function (Blueprint $table) {
+            $table->dropColumn('name');
+        });
+    }
+};

--- a/database/migrations/2025_06_03_140000_rename_title_to_name_in_systems_table.php
+++ b/database/migrations/2025_06_03_140000_rename_title_to_name_in_systems_table.php
@@ -2,6 +2,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
 
 return new class extends Migration
 {
@@ -12,8 +13,8 @@ return new class extends Migration
         });
 
         // Copy data from title to name
-        \DB::table('systems')->update([
-            'name' => \DB::raw('title')
+        DB::table('systems')->update([
+            'name' => DB::raw('title')
         ]);
 
         Schema::table('systems', function (Blueprint $table) {
@@ -28,8 +29,8 @@ return new class extends Migration
             $table->string('title')->after('id');
         });
 
-        \DB::table('systems')->update([
-            'title' => \DB::raw('name')
+        DB::table('systems')->update([
+            'title' => DB::raw('name')
         ]);
 
         Schema::table('systems', function (Blueprint $table) {

--- a/lang/en/system.php
+++ b/lang/en/system.php
@@ -10,7 +10,7 @@ return [
         'plural_label' => 'Systems',
     ],
     'form' => [
-        'title' => 'Title',
+        'name' => 'Name',
         'vendor' => 'Vendor',
         'description' => 'Description',
         'system_document_link' => 'System Documentation Link',
@@ -20,7 +20,7 @@ return [
     ],
     'table' => [
         'columns' => [
-            'title' => 'Title',
+            'name' => 'Name',
             'vendor' => 'Vendor',
             'security_password_policy_compliant' => 'Password Policy',
             'security_sso_connected' => 'SSO',


### PR DESCRIPTION
## Summary
- rename `title` column to `name` in systems table
- update SystemResource and related relation manager to use `name`
- adjust English translations

## Testing
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6846c424fdd08325905b201a54694188