### PR TITLE
Remove Implementation code field

### DIFF
--- a/app/Filament/Resources/AuditResource/Pages/CreateAudit.php
+++ b/app/Filament/Resources/AuditResource/Pages/CreateAudit.php
@@ -140,9 +140,7 @@ class CreateAudit extends CreateRecord
                                 } elseif ($audit_type == 'implementations') {
                                     $controls = Implementation::query()
                                         ->get()
-                                        ->mapWithKeys(function ($implementation) {
-                                            return [$implementation->id => $implementation->code . ' - ' . $implementation->title];
-                                        })
+                                        ->mapWithKeys(fn($implementation) => [$implementation->id => $implementation->title])
                                         ->toArray();
                                 } elseif ($audit_type == 'program') {
                                     $program_id = $get('program_id');

--- a/app/Filament/Resources/ControlResource/RelationManagers/ImplementationRelationManager.php
+++ b/app/Filament/Resources/ControlResource/RelationManagers/ImplementationRelationManager.php
@@ -4,6 +4,7 @@ namespace App\Filament\Resources\ControlResource\RelationManagers;
 
 use App\Enums\Effectiveness;
 use App\Enums\ImplementationStatus;
+use App\Filament\Resources\ImplementationResource;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Resources\RelationManagers\RelationManager;
@@ -18,92 +19,25 @@ class ImplementationRelationManager extends RelationManager
 
     public function form(Form $form): Form
     {
-        return $form
-            ->columns(2)
-            ->schema([
-                Forms\Components\TextInput::make('code')
-                    ->required()
-                    ->maxLength(255)
-                    ->placeholder('e.g. ACME-123')
-                    ->hintIcon('heroicon-m-question-mark-circle', tooltip: 'Give the implementation a unique ID or Code.'),
-                Forms\Components\Select::make('status')
-                    ->required()
-                    ->enum(ImplementationStatus::class)
-                    ->options(ImplementationStatus::class)
-                    ->default(ImplementationStatus::UNKNOWN)
-                    ->hintIcon('heroicon-m-question-mark-circle', tooltip: 'Select an implementation status. This will also be assessed in audits.')
-                    ->native(false),
-                Forms\Components\TextInput::make('title')
-                    ->columnSpanFull()
-                    ->required()
-                    ->maxLength(255)
-                    ->placeholder('e.g. Quarterly Access Reviews')
-                    ->hint('Enter the title of the implementation.')
-                    ->hintIcon('heroicon-m-question-mark-circle', tooltip: 'This should be a detailed description of this implementation in sufficient detail to both implement and test.'),
-                Forms\Components\RichEditor::make('details')
-                    ->columnSpanFull()
-                    ->disableToolbarButtons([
-                        'image',
-                        'attachFiles'
-                    ])
-                    ->label('Implementation Details')
-                    ->required()
-                    ->hintIcon('heroicon-m-question-mark-circle', tooltip: 'This should be a detailed description of this implementation in sufficient detail to both implement and test.'),
-                Forms\Components\RichEditor::make('notes')
-                    ->columnSpanFull()
-                    ->disableToolbarButtons([
-                        'image',
-                        'attachFiles'
-                    ])
-                    ->label('Internal Notes')
-                    ->hintIcon('heroicon-m-question-mark-circle', tooltip: 'These notes are for internal use only and will not be shared with auditors.')
-                    ->maxLength(4096),
-            ]);
+        return ImplementationResource::form($form)->columns(2);
     }
 
     public function table(Table $table): Table
     {
-        return $table
-            ->recordTitleAttribute('details')
-            ->columns([
-                Tables\Columns\TextColumn::make('details')
-                    ->html()
-                    ->wrap()
-                    ->searchable(),
-                Tables\Columns\TextColumn::make('status')
-                    ->badge()
-                    ->sortable(),
-                Tables\Columns\TextColumn::make('effectiveness')
-                    ->getStateUsing(fn ($record) => $record->getEffectiveness())
-                    ->badge()
-                    ->sortable(),
-                Tables\Columns\TextColumn::make('last_assessed')
-                    ->label('Last Audit')
-                    ->getStateUsing(fn ($record) => $record->getEffectivenessDate() ? $record->getEffectivenessDate() : 'Not yet audited')
-                    ->sortable(true)
-                    ->badge(),
-            ])
-            ->filters([
-                SelectFilter::make('status')->options(ImplementationStatus::class),
-                SelectFilter::make('effectiveness')->options(Effectiveness::class),
-            ])
+        return ImplementationResource::table($table)
             ->headerActions([
                 Tables\Actions\CreateAction::make(),
                 Tables\Actions\AttachAction::make()
                     ->label('Add Existing Implementation')
                     ->preloadRecordSelect()
                     ->recordSelectOptionsQuery(function (Builder $query) {
-                        $query->select(['id', 'code', 'title']); // Select only necessary columns
+                        $query->select(['id', 'title']);
                     })
-                    ->recordTitle(function ($record) {
-                        // Concatenate code and title for the option label
-                        return "({$record->code}) {$record->title}";
-                    })
-                    ->recordSelectSearchColumns(['code', 'title']),
+                    ->recordTitle(fn ($record) => $record->title)
+                    ->recordSelectSearchColumns(['title']),
             ])
             ->actions([
                 Tables\Actions\ViewAction::make(),
-                //                    ->url(fn ($record) => route('filament.app.resources.implementations.view', $record)),
             ])
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([

--- a/app/Filament/Resources/ImplementationResource.php
+++ b/app/Filament/Resources/ImplementationResource.php
@@ -53,15 +53,6 @@ class ImplementationResource extends Resource
         return $form
             ->columns(3)
             ->schema([
-                Forms\Components\TextInput::make('code')
-                    ->maxLength(255)
-                    ->required()
-                    ->unique(Implementation::class, 'code', ignoreRecord: true)
-                    ->live()
-                    ->afterStateUpdated(function (Forms\Contracts\HasForms $livewire, Forms\Components\TextInput $component) {
-                        $livewire->validateOnly($component->getStatePath());
-                    })
-                    ->hintIcon('heroicon-m-question-mark-circle', tooltip: 'Enter a unique code for this implementation. This code will be used to identify this implementation in the system.'),
                 Forms\Components\Select::make('status')
                     ->required()
                     ->label('Implementation Status')
@@ -81,7 +72,7 @@ class ImplementationResource extends Resource
                     )
                     ->searchable()
                     ->multiple()
-                    ->placeholder('Select related controls') // Optional: Adds a placeholder
+                    ->placeholder('Select related controls')
                     ->hintIcon('heroicon-m-question-mark-circle', tooltip: "All implementations should relate to a control. If you don't have a relevant control in place, consider creating a new one first."),
                 Forms\Components\TextInput::make('title')
                     ->maxLength(255)
@@ -128,11 +119,6 @@ class ImplementationResource extends Resource
             ->emptyStateHeading(__('implementation.table.empty_state.heading'))
             ->emptyStateDescription(__('implementation.table.empty_state.description'))
             ->columns([
-                Tables\Columns\TextColumn::make('code')
-                    ->label(__('implementation.table.columns.code'))
-                    ->toggleable()
-                    ->sortable()
-                    ->searchable(),
                 Tables\Columns\TextColumn::make('title')
                     ->label(__('implementation.table.columns.title'))
                     ->toggleable()
@@ -197,9 +183,8 @@ class ImplementationResource extends Resource
             ->schema([
                 Section::make('Details')
                     ->schema([
-                        TextEntry::make('code')
+                        TextEntry::make('title')
                             ->columnSpan(2)
-                            ->getStateUsing(fn($record) => "$record->code - $record->title")
                             ->label('Title'),
                         TextEntry::make('effectiveness')
                             ->getStateUsing(fn($record) => $record->getEffectiveness())
@@ -249,7 +234,7 @@ class ImplementationResource extends Resource
      */
     public static function getGlobalSearchResultTitle(Model $record): string|Htmlable
     {
-        return "$record->code - $record->title";
+        return $record->title;
     }
 
     /**
@@ -272,112 +257,7 @@ class ImplementationResource extends Resource
 
     public static function getGloballySearchableAttributes(): array
     {
-        return ['title', 'details', 'notes', 'code'];
+        return ['title', 'details', 'notes'];
     }
 
-    public static function getForm(Form $form): Form
-    {
-        return $form
-            ->schema([
-                Forms\Components\TextInput::make('code')
-                    ->required()
-                    ->maxLength(255)
-                    ->placeholder('e.g. ACME-123')
-                    ->hintIcon('heroicon-m-question-mark-circle', tooltip: 'Give the implementation a unique ID or Code.'),
-                Forms\Components\Select::make('status')
-                    ->required()
-                    ->enum(ImplementationStatus::class)
-                    ->options(ImplementationStatus::class)
-                    ->default(ImplementationStatus::UNKNOWN)
-                    ->hintIcon('heroicon-m-question-mark-circle', tooltip: 'Select an implementation status. This will also be assessed in audits.')
-                    ->native(false),
-                Forms\Components\TextInput::make('title')
-                    ->columnSpanFull()
-                    ->required()
-                    ->maxLength(255)
-                    ->placeholder('e.g. Quarterly Access Reviews')
-                    ->hint('Enter the title of the implementation.')
-                    ->hintIcon('heroicon-m-question-mark-circle', tooltip: 'This should be a detailed description of this implementation in sufficient detail to both implement and test.'),
-                Forms\Components\RichEditor::make('details')
-                    ->columnSpanFull()
-                    ->disableToolbarButtons([
-                        'image',
-                        'attachFiles'
-                    ])
-                    ->label('Implementation Details')
-                    ->required()
-                    ->hintIcon('heroicon-m-question-mark-circle', tooltip: 'This should be a detailed description of this implementation in sufficient detail to both implement and test.'),
-                Forms\Components\RichEditor::make('notes')
-                    ->columnSpanFull()
-                    ->disableToolbarButtons([
-                        'image',
-                        'attachFiles'
-                    ])
-                    ->label('Internal Notes')
-                    ->hintIcon('heroicon-m-question-mark-circle', tooltip: 'These notes are for internal use only and will not be shared with auditors.')
-                    ->maxLength(4096),
-            ]);
-    }
-
-    public static function getTable(Table $table): Table
-    {
-        return $table
-            ->recordTitleAttribute('details')
-            ->columns([
-                Tables\Columns\TextColumn::make('code')
-                    ->toggleable()
-                    ->sortable()
-                    ->searchable(),
-                Tables\Columns\TextColumn::make('title')
-                    ->toggleable()
-                    ->sortable()
-                    ->searchable(),
-                Tables\Columns\TextColumn::make('effectiveness')
-                    ->getStateUsing(function ($record) {
-                        return $record->getEffectiveness();
-                    })
-                    ->badge(),
-                Tables\Columns\TextColumn::make('last_assessed')
-                    ->label('Last Audit')
-                    ->getStateUsing(fn($record) => $record->getEffectivenessDate() ? $record->getEffectivenessDate() : 'Not yet audited')
-                    ->badge(),
-                Tables\Columns\TextColumn::make('status')
-                    ->toggleable()
-                    ->sortable()
-                    ->searchable(),
-                Tables\Columns\TextColumn::make('created_at')
-                    ->dateTime()
-                    ->sortable()
-                    ->toggleable(isToggledHiddenByDefault: true),
-                Tables\Columns\TextColumn::make('updated_at')
-                    ->dateTime()
-                    ->sortable()
-                    ->toggleable(isToggledHiddenByDefault: true),
-            ])
-            ->filters([
-                SelectFilter::make('status')->options(ImplementationStatus::class),
-                SelectFilter::make('effectiveness')
-                    ->options(Effectiveness::class)
-                    ->query(function (Builder $query, array $data) {
-                        if (! isset($data['value'])) {
-                            return $query;
-                        }
-
-                        return $query->whereHas('auditItems', function ($q) use ($data) {
-                            $q->where('effectiveness', $data['value']);
-                        });
-                    }),
-            ])
-            ->actions([
-                Tables\Actions\ViewAction::make(),
-                Tables\Actions\EditAction::make(),
-            ])
-            ->bulkActions([
-                Tables\Actions\BulkActionGroup::make([
-                    Tables\Actions\DeleteBulkAction::make(),
-                    Tables\Actions\ForceDeleteBulkAction::make(),
-                    Tables\Actions\RestoreBulkAction::make(),
-                ]),
-            ]);
-    }
 }

--- a/app/Filament/Resources/RiskResource/RelationManagers/ImplementationsRelationManager.php
+++ b/app/Filament/Resources/RiskResource/RelationManagers/ImplementationsRelationManager.php
@@ -14,12 +14,12 @@ class ImplementationsRelationManager extends RelationManager
 
     public function form(Form $form): Form
     {
-        return ImplementationResource::getForm($form);
+        return ImplementationResource::form($form);
     }
 
     public function table(Table $table): Table
     {
-        $table = ImplementationResource::getTable($table);
+        $table = ImplementationResource::table($table);
         $table->actions([
             Tables\Actions\ViewAction::make()->hidden(),
         ]);

--- a/database/factories/ImplementationFactory.php
+++ b/database/factories/ImplementationFactory.php
@@ -15,7 +15,6 @@ class ImplementationFactory extends Factory
     public function definition(): array
     {
         return [
-            'code' => $this->faker->word(),
             'title' => $this->faker->word(),
             'details' => $this->faker->text(),
             'status' => $this->faker->randomElement(ImplementationStatus::class),

--- a/database/migrations/2025_06_04_000000_drop_code_from_implementations_table.php
+++ b/database/migrations/2025_06_04_000000_drop_code_from_implementations_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('implementations', function (Blueprint $table) {
+            if (Schema::hasColumn('implementations', 'code')) {
+                $table->dropColumn('code');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('implementations', function (Blueprint $table) {
+            if (! Schema::hasColumn('implementations', 'code')) {
+                $table->string('code')->nullable();
+            }
+        });
+    }
+};

--- a/database/seeders/DemoSeeder.php
+++ b/database/seeders/DemoSeeder.php
@@ -153,7 +153,6 @@ class DemoSeeder extends Seeder
         $implementationsData = [
 
             'IMPL-L1' => [
-                'code' => 'IMPL-L1',
                 'title' => 'EDR Deployment on Workstations',
                 'details' => 'Enterprise Detection and Response (EDR) tool, specifically Microsoft Defender, is deployed across all workstations within the organization. Configuration settings are optimized for maximum detection efficiency and minimal performance impact. Continuous monitoring and automatic updates are enabled to ensure up-to-date protection against emerging threats.',
                 'notes' => 'Currently, Microsoft Defender is deployed on all Windows workstations through Group Policy Object (GPO). However, the implementation does not yet cover servers and Linux machines. A plan is needed to extend EDR coverage to these systems, ensuring comprehensive protection across the entire network. Additionally, compatibility and deployment strategies for non-Windows systems need to be developed.',
@@ -161,7 +160,6 @@ class DemoSeeder extends Seeder
             ],
 
             'IMPL-L2' => [
-                'code' => 'IMPL-L2',
                 'title' => 'Data Encryption',
                 'details' => 'All sensitive data stored on company servers and transmitted over the network is encrypted using AES-256 encryption standards. Encryption keys are managed through a centralized key management system with strict access controls.',
                 'notes' => 'Data encryption is fully implemented for data at rest. Work is ongoing to ensure encryption for data in transit across all platforms. Key rotation policy needs to be established and automated.',
@@ -169,7 +167,6 @@ class DemoSeeder extends Seeder
             ],
 
             'IMPL-L3' => [
-                'code' => 'IMPL-L3',
                 'title' => 'Security Audits',
                 'details' => 'Quarterly security audits are conducted by an internal team, supplemented by an annual audit performed by an external agency. The focus is on network security, policy compliance, and incident response readiness.',
                 'notes' => 'Internal audit processes are well-established. Need to finalize the contract with the external agency for annual audits. Also, integrating audit findings into continuous improvement processes is in progress.',
@@ -177,7 +174,6 @@ class DemoSeeder extends Seeder
             ],
 
             'IMPL-L4' => [
-                'code' => 'IMPL-L4',
                 'title' => 'Incident Response Plan',
                 'details' => 'A detailed incident response plan has been developed, covering a range of potential scenarios. Regular training and simulated incident response exercises are conducted to ensure preparedness.',
                 'notes' => 'The plan is currently being reviewed for updates based on recent threat landscape changes. Need to schedule the next round of simulation exercises for the new team members.',
@@ -185,7 +181,6 @@ class DemoSeeder extends Seeder
             ],
 
             'IMPL-L5' => [
-                'code' => 'IMPL-L5',
                 'title' => 'Access Management',
                 'details' => 'Access management is enforced using a centralized identity management system. Regular audits are performed to ensure adherence to the least privilege principle and to update access rights based on role changes.',
                 'notes' => 'Implementation of the new identity management system is ongoing. Transition from the old system requires careful handling of legacy data and access rights.',
@@ -193,7 +188,6 @@ class DemoSeeder extends Seeder
             ],
 
             'IMPL-L6' => [
-                'code' => 'IMPL-L6',
                 'title' => 'Cybersecurity Awareness Training',
                 'details' => 'All employees undergo mandatory cybersecurity awareness training upon onboarding, with annual refresher courses. The training program includes modules on phishing, secure password practices, and secure internet usage.',
                 'notes' => 'The training curriculum is currently being updated to include recent cybersecurity trends and threats. Additionally, exploring options for more interactive and engaging training methods.',
@@ -201,7 +195,6 @@ class DemoSeeder extends Seeder
             ],
 
             'IMPL-L7' => [
-                'code' => 'IMPL-L7',
                 'title' => 'Network Layered Defense',
                 'details' => 'Network architecture includes layered defenses with firewalls, IDS/IPS, and segregated network zones. Regular reviews and updates are conducted to ensure the architecture aligns with current threat intelligence.',
                 'notes' => 'Recent network expansion has introduced new challenges in maintaining segmentation. An audit of the current network setup is planned to identify potential improvements.',
@@ -209,7 +202,6 @@ class DemoSeeder extends Seeder
             ],
 
             'IMPL-L8' => [
-                'code' => 'IMPL-L8',
                 'title' => 'Vulnerability Scanning and Patch Management',
                 'details' => 'Vulnerability scanning is conducted bi-weekly, with immediate action on critical vulnerabilities. Patch management is automated for standard software and manually reviewed for critical systems.',
                 'notes' => 'Integrating newer scanning tools to cover cloud and containerized environments. Need to streamline patch management for quicker response.',
@@ -217,7 +209,6 @@ class DemoSeeder extends Seeder
             ],
 
             'IMPL-L9' => [
-                'code' => 'IMPL-L9',
                 'title' => 'MFA Enforcement',
                 'details' => 'MFA is enforced for access to all internal systems and cloud services. The implementation includes a combination of hardware tokens, SMS, and mobile app authentication.',
                 'notes' => 'User adoption of MFA has been successful, but there are ongoing challenges with hardware token distribution for remote workers. Exploring more scalable solutions.',
@@ -225,7 +216,6 @@ class DemoSeeder extends Seeder
             ],
 
             'IMPL-L10' => [
-                'code' => 'IMPL-L10',
                 'title' => 'Third-Party Risk Management',
                 'details' => 'A third-party risk management program is established, including regular security assessments of vendors and incorporation of security clauses in vendor contracts.',
                 'notes' => 'Currently updating the risk assessment framework to include newer types of third-party services. Need to work on improving the contract negotiation process for better security alignment.',
@@ -255,8 +245,8 @@ class DemoSeeder extends Seeder
 
             // Insert Implementations
             $implementationModels = [];
-            foreach ($implementationsData as $implementationData) {
-                $implementationModels[$implementationData['code']] = Implementation::create($implementationData);
+            foreach ($implementationsData as $key => $implementationData) {
+                $implementationModels[$key] = Implementation::create($implementationData);
             }
 
             // Establish Relationships

--- a/lang/en/implementation.php
+++ b/lang/en/implementation.php
@@ -15,7 +15,6 @@ return [
             'description' => 'Try creating a new implementation by clicking the "Create Implementation" button above.',
         ],
         'columns' => [
-            'code' => 'Code',
             'title' => 'Title',
             'effectiveness' => 'Effectiveness',
             'last_assessed' => 'Last Audit',

--- a/lang/es/implementation.php
+++ b/lang/es/implementation.php
@@ -15,7 +15,6 @@ return [
             'description' => 'Intente crear una nueva implementación haciendo clic en el botón "Crear Implementación" de arriba.',
         ],
         'columns' => [
-            'code' => 'Código',
             'title' => 'Título',
             'effectiveness' => 'Efectividad',
             'last_assessed' => 'Última Auditoría',

--- a/lang/fr/implementation.php
+++ b/lang/fr/implementation.php
@@ -15,7 +15,6 @@ return [
             'description' => 'Essayez de créer une nouvelle implémentation en cliquant sur le bouton "Créer une Implémentation" ci-dessus.',
         ],
         'columns' => [
-            'code' => 'Code',
             'title' => 'Titre',
             'effectiveness' => 'Efficacité',
             'last_assessed' => 'Dernier Audit',

--- a/lang/hr/implementation.php
+++ b/lang/hr/implementation.php
@@ -15,7 +15,6 @@ return [
             'description' => 'Pokušajte kreirati novu implementaciju klikom na gumb "Kreiraj Implementaciju" iznad.',
         ],
         'columns' => [
-            'code' => 'Kod',
             'title' => 'Naslov',
             'effectiveness' => 'Učinkovitost',
             'last_assessed' => 'Zadnja Revizija',

--- a/resources/views/tables/implementations-table.blade.php
+++ b/resources/views/tables/implementations-table.blade.php
@@ -5,7 +5,6 @@
     <table class="w-full text-sm text-left rtl:text-right text-black dark:text-gray-400">
         <thead class="text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-700 dark:text-gray-400">
         <tr>
-            <th scope="col" class="border px-4 py-2">Code</th>
             <th scope="col" class="border px-4 py-2">Title</th>
             <th scope="col" class="border px-4 py-2">Details</th>
             </tr>
@@ -14,7 +13,6 @@
 
         @foreach ($implementations as $implementation)
         <tr>
-            <td class="border px-4 py-2"> {{ $implementation->code }}</td>
             <td class="border px-4 py-2">{{ $implementation->title }}</td>
             <td class="border px-4 py-2"> {!! $implementation->details !!} </td>
             </tr>

--- a/tests/Feature/StandardControlImplementationTest.php
+++ b/tests/Feature/StandardControlImplementationTest.php
@@ -72,7 +72,6 @@ class StandardControlImplementationTest extends TestCase
                 // Create 10 implementations for each control
                 for ($j = 1; $j <= 10; $j++) {
                     $implementation = Implementation::create([
-                        'code' => "IMPL-{$s}-{$i}-{$j}",
                         'title' => "Implementation {$j} for Control {$s}-{$i}",
                         'details' => "Detailed implementation steps for Control {$s}-{$i}, Implementation {$j}",
                         'notes' => "Internal notes for Implementation {$j} of Standard {$s}",
@@ -84,7 +83,7 @@ class StandardControlImplementationTest extends TestCase
                     $control->implementations()->attach($implementation->id);
 
                     $this->assertDatabaseHas('implementations', [
-                        'code' => "IMPL-{$s}-{$i}-{$j}",
+                        'title' => "Implementation {$j} for Control {$s}-{$i}",
                     ]);
 
                     $this->assertDatabaseHas('control_implementation', [


### PR DESCRIPTION
## Summary
- remove code from ImplementationResource form/table
- drop `code` column using new migration
- revert original migrations
- keep ImplementationResource as single source for form and table

## Testing
- `composer test` *(fails: command not found)*
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6846d32681c88325be7f482529a399fa